### PR TITLE
Update ProbeService.java ready only if running

### DIFF
--- a/kstreamplify-core/src/main/java/com/michelin/kstreamplify/services/ProbeService.java
+++ b/kstreamplify-core/src/main/java/com/michelin/kstreamplify/services/ProbeService.java
@@ -49,7 +49,7 @@ public final class ProbeService {
                 }
             }
 
-            return kafkaStreamsInitializer.getKafkaStreams().state().isRunningOrRebalancing()
+            return kafkaStreamsInitializer.getKafkaStreams().state().equals(KafkaStreams.State.RUNNING)
                 ? RestServiceResponse.<String>builder().status(HttpURLConnection.HTTP_OK).build() :
                 RestServiceResponse.<String>builder().status(HttpURLConnection.HTTP_UNAVAILABLE)
                     .build();


### PR DESCRIPTION
In kubernetes, readiness are used to determine if a loadbalancer can forward request to a pod. If a pod declare that he is ready, he will receive traffic. (https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes)

The readiness for a kafka stream application is useful if we want to deploy a rest endpoint on top of it like an interactive query. (https://docs.confluent.io/platform/current/streams/developer-guide/interactive-queries.html) In such a case, we do not want a pod to pretend that it is ready if it is rebalancing, since it is potentially transferring state stores and therefore is in a potentially inconsistent state.