### PR TITLE
Give the possibility to override the properties in KafkaStreamsStarterTest

### DIFF
--- a/kstreamplify-core-test/src/main/java/com/michelin/kstreamplify/KafkaStreamsStarterTest.java
+++ b/kstreamplify-core-test/src/main/java/com/michelin/kstreamplify/KafkaStreamsStarterTest.java
@@ -47,12 +47,12 @@ public abstract class KafkaStreamsStarterTest {
         Properties properties = new Properties();
         properties.setProperty(StreamsConfig.APPLICATION_ID_CONFIG, "test");
         properties.setProperty(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "mock:1234");
-        properties.setProperty(StreamsConfig.STATE_DIR_CONFIG, STATE_DIR + getClass().getName());
+        properties.setProperty(StreamsConfig.STATE_DIR_CONFIG, getStoragePath() );
 
         KafkaStreamsExecutionContext.registerProperties(properties);
         KafkaStreamsExecutionContext.setSerdesConfig(Collections
             .singletonMap(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
-                "mock://" + getClass().getName()));
+                "mock://" + getClass().getSimpleName()));
 
         var starter = getKafkaStreamsStarter();
 
@@ -85,13 +85,22 @@ public abstract class KafkaStreamsStarterTest {
     }
 
     /**
+     * Default storage path for the storage directory.
+     *
+     * @return The default storage path
+     */
+    protected String getStoragePath() {
+        return STATE_DIR + getClass().getSimpleName();
+    }
+    
+    /**
      * Method to close everything properly at the end of the test.
      */
     @AfterEach
     void generalTearDown() throws IOException {
         testDriver.close();
-        Files.deleteIfExists(Paths.get(STATE_DIR + getClass().getName()));
-        MockSchemaRegistry.dropScope("mock://" + getClass().getName());
+        Files.deleteIfExists(Paths.get( getStoragePath() ));
+        MockSchemaRegistry.dropScope("mock://" + getClass().getSimpleName());
     }
 
     /**

--- a/kstreamplify-core-test/src/main/java/com/michelin/kstreamplify/KafkaStreamsStarterTest.java
+++ b/kstreamplify-core-test/src/main/java/com/michelin/kstreamplify/KafkaStreamsStarterTest.java
@@ -1,5 +1,7 @@
 package com.michelin.kstreamplify;
 
+import static org.apache.kafka.streams.StreamsConfig.STATE_DIR_CONFIG;
+
 import com.michelin.kstreamplify.avro.KafkaError;
 import com.michelin.kstreamplify.context.KafkaStreamsExecutionContext;
 import com.michelin.kstreamplify.initializer.KafkaStreamsStarter;
@@ -22,8 +24,6 @@ import org.apache.kafka.streams.TestOutputTopic;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-
-import static org.apache.kafka.streams.StreamsConfig.STATE_DIR_CONFIG;
 
 /**
  * <p>The main test class to extend to execute unit tests on topology</p>.
@@ -49,7 +49,7 @@ public abstract class KafkaStreamsStarterTest {
     void generalSetUp() {
         Properties properties = getProperties();
 
-        KafkaStreamsExecutionContext.registerProperties( properties );
+        KafkaStreamsExecutionContext.registerProperties(properties);
         KafkaStreamsExecutionContext.setSerdesConfig(Collections
             .singletonMap(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
                 "mock://" + getClass().getSimpleName()));
@@ -79,11 +79,11 @@ public abstract class KafkaStreamsStarterTest {
         // Default properties
         properties.setProperty(StreamsConfig.APPLICATION_ID_CONFIG, "test");
         properties.setProperty(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "mock:1234");
-        properties.setProperty(StreamsConfig.STATE_DIR_CONFIG, STATE_DIR + getClass().getSimpleName() );
+        properties.setProperty(StreamsConfig.STATE_DIR_CONFIG, STATE_DIR + getClass().getSimpleName());
         
         // Add specific properties or overwrite default properties
         HashMap<String, String> propertiesMap = getSpecificProperties();
-        if (propertiesMap != null && !propertiesMap.isEmpty() ) {
+        if (propertiesMap != null && !propertiesMap.isEmpty()) {
             properties.putAll(propertiesMap);
         }
         
@@ -111,7 +111,9 @@ public abstract class KafkaStreamsStarterTest {
      *
      * @return new/overwrite properties
      */
-    protected HashMap<String, String> getSpecificProperties() {return new HashMap<>();}
+    protected HashMap<String, String> getSpecificProperties() {
+        return new HashMap<>();
+    }
     
     /**
      * Method to close everything properly at the end of the test.
@@ -119,7 +121,7 @@ public abstract class KafkaStreamsStarterTest {
     @AfterEach
     void generalTearDown() throws IOException {
         testDriver.close();
-        Files.deleteIfExists(Paths.get( KafkaStreamsExecutionContext.getProperties().getProperty(STATE_DIR_CONFIG) ));
+        Files.deleteIfExists(Paths.get(KafkaStreamsExecutionContext.getProperties().getProperty(STATE_DIR_CONFIG)));
         MockSchemaRegistry.dropScope("mock://" + getClass().getSimpleName());
     }
 

--- a/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/ConfigErrorHandlerTest.java
+++ b/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/ConfigErrorHandlerTest.java
@@ -3,11 +3,13 @@ package com.michelin.kstreamplify;
 import com.michelin.kstreamplify.context.KafkaStreamsExecutionContext;
 import com.michelin.kstreamplify.initializer.KafkaStreamsStarter;
 import org.apache.kafka.streams.StreamsBuilder;
-import org.apache.kafka.streams.StreamsConfig;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.Properties;
+
+import static org.apache.kafka.streams.StreamsConfig.STATE_DIR_CONFIG;
 
 class ConfigErrorHandlerTest extends KafkaStreamsStarterTest {
 
@@ -28,18 +30,26 @@ class ConfigErrorHandlerTest extends KafkaStreamsStarterTest {
         };
     }
 
+    /**
+     * Overwrite the default storage path.
+     *
+     * @return the new/overwrite properties
+     */
     @Override
-    protected String getStoragePath() {
-        return SPECIFIC_STORAGE_PATH;
+    protected HashMap<String, String> getSpecificProperties() {
+        HashMap<String, String> propertiesMap = new HashMap<>();
+        propertiesMap.put(STATE_DIR_CONFIG, SPECIFIC_STORAGE_PATH);
+        
+        return propertiesMap;
     }
 
     /**
      * Test when the default storage path is override.
      */
     @Test
-    void testSpecificStoragePath() {
+    void shouldValidateStorageDirHasBeenOverride(){
         Properties properties = KafkaStreamsExecutionContext.getProperties();
-        Assertions.assertEquals(SPECIFIC_STORAGE_PATH, properties.getProperty(StreamsConfig.STATE_DIR_CONFIG));
+        Assertions.assertEquals(SPECIFIC_STORAGE_PATH, properties.getProperty(STATE_DIR_CONFIG));
     }
 
 }

--- a/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/ConfigErrorHandlerTest.java
+++ b/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/ConfigErrorHandlerTest.java
@@ -1,0 +1,45 @@
+package com.michelin.kstreamplify;
+
+import com.michelin.kstreamplify.context.KafkaStreamsExecutionContext;
+import com.michelin.kstreamplify.initializer.KafkaStreamsStarter;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+class ConfigErrorHandlerTest extends KafkaStreamsStarterTest {
+
+    private static final String DLQ_TOPIC = "dlqTopic";
+    private static final String SPECIFIC_STORAGE_PATH = "/tmp/PersonalPath";
+    
+    @Override
+    protected KafkaStreamsStarter getKafkaStreamsStarter() {
+        return new KafkaStreamsStarter() {
+            @Override
+            public String dlqTopic() {
+                return DLQ_TOPIC;
+            }
+
+            @Override
+            public void topology(StreamsBuilder streamsBuilder) {
+            }
+        };
+    }
+
+    @Override
+    protected String getStoragePath() {
+        return SPECIFIC_STORAGE_PATH;
+    }
+
+    /**
+     * Test when the default storage path is override.
+     */
+    @Test
+    void testSpecificStoragePath() {
+        Properties properties = KafkaStreamsExecutionContext.getProperties();
+        Assertions.assertEquals(SPECIFIC_STORAGE_PATH, properties.getProperty(StreamsConfig.STATE_DIR_CONFIG));
+    }
+
+}

--- a/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/ConfigErrorHandlerTest.java
+++ b/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/ConfigErrorHandlerTest.java
@@ -1,15 +1,14 @@
 package com.michelin.kstreamplify;
 
+import static org.apache.kafka.streams.StreamsConfig.STATE_DIR_CONFIG;
+
 import com.michelin.kstreamplify.context.KafkaStreamsExecutionContext;
 import com.michelin.kstreamplify.initializer.KafkaStreamsStarter;
 import org.apache.kafka.streams.StreamsBuilder;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
 import java.util.HashMap;
 import java.util.Properties;
-
-import static org.apache.kafka.streams.StreamsConfig.STATE_DIR_CONFIG;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 class ConfigErrorHandlerTest extends KafkaStreamsStarterTest {
 

--- a/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/OverridePropertiesTest.java
+++ b/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/OverridePropertiesTest.java
@@ -4,13 +4,13 @@ import static org.apache.kafka.streams.StreamsConfig.STATE_DIR_CONFIG;
 
 import com.michelin.kstreamplify.context.KafkaStreamsExecutionContext;
 import com.michelin.kstreamplify.initializer.KafkaStreamsStarter;
-import org.apache.kafka.streams.StreamsBuilder;
 import java.util.HashMap;
 import java.util.Properties;
+import org.apache.kafka.streams.StreamsBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-class ConfigErrorHandlerTest extends KafkaStreamsStarterTest {
+class OverridePropertiesTest extends KafkaStreamsStarterTest {
 
     private static final String DLQ_TOPIC = "dlqTopic";
     private static final String SPECIFIC_STORAGE_PATH = "/tmp/PersonalPath";
@@ -46,7 +46,7 @@ class ConfigErrorHandlerTest extends KafkaStreamsStarterTest {
      * Test when the default storage path is override.
      */
     @Test
-    void shouldValidateStorageDirHasBeenOverride(){
+    void shouldValidateStorageDirHasBeenOverride() {
         Properties properties = KafkaStreamsExecutionContext.getProperties();
         Assertions.assertEquals(SPECIFIC_STORAGE_PATH, properties.getProperty(STATE_DIR_CONFIG));
     }

--- a/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/TopologyErrorHandlerTest.java
+++ b/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/TopologyErrorHandlerTest.java
@@ -16,7 +16,6 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.StreamsBuilder;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TestOutputTopic;
 import org.apache.kafka.streams.kstream.Consumed;
@@ -25,6 +24,7 @@ import org.apache.kafka.streams.kstream.Produced;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import static org.apache.kafka.streams.StreamsConfig.STATE_DIR_CONFIG;
 
 class TopologyErrorHandlerTest extends KafkaStreamsStarterTest {
     private static final String AVRO_TOPIC = "avroTopic";
@@ -160,8 +160,8 @@ class TopologyErrorHandlerTest extends KafkaStreamsStarterTest {
      * Test the default storage path.
      */
     @Test
-    void testDefaultStoragePath() {
+    void shouldValidateDefaultStorageDir() {
         Properties properties = KafkaStreamsExecutionContext.getProperties();
-        Assertions.assertEquals("/tmp/kafka-streams/" + getClass().getSimpleName(), properties.getProperty(StreamsConfig.STATE_DIR_CONFIG));
+        Assertions.assertEquals("/tmp/kafka-streams/" + getClass().getSimpleName(), properties.getProperty(STATE_DIR_CONFIG));
     }
 }

--- a/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/TopologyErrorHandlerTest.java
+++ b/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/TopologyErrorHandlerTest.java
@@ -1,7 +1,7 @@
 package com.michelin.kstreamplify;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.apache.kafka.streams.StreamsConfig.STATE_DIR_CONFIG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.michelin.kstreamplify.avro.KafkaError;
 import com.michelin.kstreamplify.context.KafkaStreamsExecutionContext;
@@ -161,7 +161,7 @@ class TopologyErrorHandlerTest extends KafkaStreamsStarterTest {
     @Test
     void shouldValidateDefaultStorageDir() {
         Properties properties = KafkaStreamsExecutionContext.getProperties();
-        Assertions.assertEquals("/tmp/kafka-streams/" + getClass().getSimpleName()
-                                , properties.getProperty(STATE_DIR_CONFIG));
+        Assertions.assertEquals("/tmp/kafka-streams/" + getClass().getSimpleName(),
+                                properties.getProperty(STATE_DIR_CONFIG));
     }
 }

--- a/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/TopologyErrorHandlerTest.java
+++ b/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/TopologyErrorHandlerTest.java
@@ -3,21 +3,26 @@ package com.michelin.kstreamplify;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.michelin.kstreamplify.avro.KafkaError;
+import com.michelin.kstreamplify.context.KafkaStreamsExecutionContext;
 import com.michelin.kstreamplify.error.ProcessingResult;
 import com.michelin.kstreamplify.error.TopologyErrorHandler;
 import com.michelin.kstreamplify.initializer.KafkaStreamsStarter;
 import com.michelin.kstreamplify.serde.SerdesUtils;
 import com.michelin.kstreamplify.serde.TopicWithSerde;
 import java.util.List;
+import java.util.Properties;
+
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TestOutputTopic;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Produced;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -149,5 +154,14 @@ class TopologyErrorHandlerTest extends KafkaStreamsStarterTest {
 
         assertEquals("TestOutputTopic[topic='OUTPUT_TOPIC', keyDeserializer=StringDeserializer, "
             + "valueDeserializer=StringDeserializer, size=0]", outputTopic.toString());
+    }
+
+    /**
+     * Test the default storage path.
+     */
+    @Test
+    void testDefaultStoragePath() {
+        Properties properties = KafkaStreamsExecutionContext.getProperties();
+        Assertions.assertEquals("/tmp/kafka-streams/" + getClass().getSimpleName(), properties.getProperty(StreamsConfig.STATE_DIR_CONFIG));
     }
 }

--- a/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/TopologyErrorHandlerTest.java
+++ b/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/TopologyErrorHandlerTest.java
@@ -1,6 +1,7 @@
 package com.michelin.kstreamplify;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.apache.kafka.streams.StreamsConfig.STATE_DIR_CONFIG;
 
 import com.michelin.kstreamplify.avro.KafkaError;
 import com.michelin.kstreamplify.context.KafkaStreamsExecutionContext;
@@ -11,7 +12,6 @@ import com.michelin.kstreamplify.serde.SerdesUtils;
 import com.michelin.kstreamplify.serde.TopicWithSerde;
 import java.util.List;
 import java.util.Properties;
-
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -24,7 +24,6 @@ import org.apache.kafka.streams.kstream.Produced;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.apache.kafka.streams.StreamsConfig.STATE_DIR_CONFIG;
 
 class TopologyErrorHandlerTest extends KafkaStreamsStarterTest {
     private static final String AVRO_TOPIC = "avroTopic";
@@ -162,6 +161,7 @@ class TopologyErrorHandlerTest extends KafkaStreamsStarterTest {
     @Test
     void shouldValidateDefaultStorageDir() {
         Properties properties = KafkaStreamsExecutionContext.getProperties();
-        Assertions.assertEquals("/tmp/kafka-streams/" + getClass().getSimpleName(), properties.getProperty(STATE_DIR_CONFIG));
+        Assertions.assertEquals("/tmp/kafka-streams/" + getClass().getSimpleName()
+                                , properties.getProperty(STATE_DIR_CONFIG));
     }
 }


### PR DESCRIPTION
Removed the package name in the storage path for the TU. Add the possibility to overwrite the storage path for the TU.