### PR TITLE
Do not expose full configuration in the logs to avoid to leak secrets.

### DIFF
--- a/kstreamplify-core/src/main/java/com/michelin/kstreamplify/context/KafkaStreamsExecutionContext.java
+++ b/kstreamplify-core/src/main/java/com/michelin/kstreamplify/context/KafkaStreamsExecutionContext.java
@@ -73,10 +73,5 @@ public class KafkaStreamsExecutionContext {
         }
 
         KafkaStreamsExecutionContext.properties = properties;
-        StringBuilder stringBuilderProperties = new StringBuilder("Kafka Stream properties:\n");
-        properties.forEach(
-            (key, value) -> stringBuilderProperties.append("\t").append(key).append(" = ")
-                .append(value).append("\n"));
-        log.info(stringBuilderProperties.toString());
     }
 }


### PR DESCRIPTION
Kafka Streams already expose this in a secure way.