### PR TITLE
Poc/dedup with store migration

### DIFF
--- a/kstreamplify-core/src/main/java/com/michelin/kstreamplify/deduplication/AbstractDedup.java
+++ b/kstreamplify-core/src/main/java/com/michelin/kstreamplify/deduplication/AbstractDedup.java
@@ -1,0 +1,37 @@
+package com.michelin.kstreamplify.deduplication;
+
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.TimestampedKeyValueStore;
+import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.apache.kafka.streams.state.WindowStore;
+
+/**
+ * Deduplication Abstract class.
+ */
+public abstract class AbstractDedup<V> {
+
+    /**
+     *  Migrate data from timestampKeyValueStore to dedupWindowStore.
+     *
+     * @param timestampKeyValueStore timestamp key value store for input data
+     * @param dedupWindowStore window store for output data
+     *
+     */
+    public void migrateDataToWindowStore(
+            TimestampedKeyValueStore<String, V> timestampKeyValueStore,
+            WindowStore<String, V> dedupWindowStore) {
+        KeyValueIterator<String, ValueAndTimestamp<V>> iterator = timestampKeyValueStore.all();
+
+        while (iterator.hasNext()) {
+            KeyValue<String, ValueAndTimestamp<V>> entry = iterator.next();
+            String key = entry.key;
+            V value = entry.value.value();
+
+            dedupWindowStore.put(key, value, entry.value.timestamp());
+            timestampKeyValueStore.delete(key);
+        }
+
+        iterator.close();
+    }
+}

--- a/kstreamplify-core/src/main/java/com/michelin/kstreamplify/deduplication/DedupKeyProcessor.java
+++ b/kstreamplify-core/src/main/java/com/michelin/kstreamplify/deduplication/DedupKeyProcessor.java
@@ -1,13 +1,19 @@
 package com.michelin.kstreamplify.deduplication;
 
 import com.michelin.kstreamplify.error.ProcessingResult;
-import java.time.Duration;
-import java.time.Instant;
 import org.apache.avro.specific.SpecificRecord;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.ProcessorContext;
 import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.TimestampedKeyValueStore;
+import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.streams.state.WindowStore;
+
+import java.time.Duration;
+import java.time.Instant;
 
 /**
  * Transformer class for the deduplication mechanism on keys of a given topic.
@@ -15,7 +21,7 @@ import org.apache.kafka.streams.state.WindowStore;
  * @param <V> The type of the value
  */
 public class DedupKeyProcessor<V extends SpecificRecord>
-    implements Processor<String, V, String, ProcessingResult<V, V>> {
+        implements Processor<String, V, String, ProcessingResult<V, V>> {
 
     /**
      * Kstream context for this transformer.
@@ -28,9 +34,20 @@ public class DedupKeyProcessor<V extends SpecificRecord>
     private WindowStore<String, String> dedupWindowStore;
 
     /**
+     * TimestampKeyValue store containing all the records to migrate into Window store.
+     */
+    private TimestampedKeyValueStore<String, String> timestampKeyValueStore;
+
+    /**
      * Window store name, initialized @ construction.
      */
     private final String windowStoreName;
+
+    /**
+     * TimestampKeyValue store name, initialized @ construction.
+     */
+    private final String timestampKeyValueStoreName;
+
 
     /**
      * Retention window for the state store. Used for fetching data.
@@ -43,8 +60,9 @@ public class DedupKeyProcessor<V extends SpecificRecord>
      * @param windowStoreName         The name of the constructor
      * @param retentionWindowDuration The retentionWindow Duration
      */
-    public DedupKeyProcessor(String windowStoreName, Duration retentionWindowDuration) {
+    public DedupKeyProcessor(String windowStoreName, Duration retentionWindowDuration, String timestampKeyValueStoreName) {
         this.windowStoreName = windowStoreName;
+        this.timestampKeyValueStoreName = timestampKeyValueStoreName;
         this.retentionWindowDuration = retentionWindowDuration;
     }
 
@@ -52,6 +70,27 @@ public class DedupKeyProcessor<V extends SpecificRecord>
     public void init(ProcessorContext<String, ProcessingResult<V, V>> context) {
         processorContext = context;
         dedupWindowStore = this.processorContext.getStateStore(windowStoreName);
+        if (!StringUtils.isEmpty(timestampKeyValueStoreName)) {
+            timestampKeyValueStore = this.processorContext.getStateStore(timestampKeyValueStoreName);
+            migrateDataToWindowStore();
+        }
+    }
+
+    private void migrateDataToWindowStore() {
+        KeyValueIterator<String, ValueAndTimestamp<String>> iterator = timestampKeyValueStore.all();
+
+        while (iterator.hasNext()) {
+            KeyValue<String, ValueAndTimestamp<String>> entry = iterator.next();
+            String key = entry.key;
+            String value = entry.value.value();
+
+
+            // Insérer les données dans le WindowStore
+            dedupWindowStore.put(key, value, entry.value.timestamp());
+            timestampKeyValueStore.delete(key);
+        }
+
+        iterator.close();
     }
 
     @Override
@@ -62,8 +101,8 @@ public class DedupKeyProcessor<V extends SpecificRecord>
 
             // Retrieve all the matching keys in the stateStore and return null if found it (signaling a duplicate)
             try (var resultIterator = dedupWindowStore.backwardFetch(message.key(),
-                currentInstant.minus(retentionWindowDuration),
-                currentInstant.plus(retentionWindowDuration))) {
+                    currentInstant.minus(retentionWindowDuration),
+                    currentInstant.plus(retentionWindowDuration))) {
                 while (resultIterator != null && resultIterator.hasNext()) {
                     var currentKeyValue = resultIterator.next();
                     if (message.key().equals(currentKeyValue.value)) {
@@ -77,8 +116,8 @@ public class DedupKeyProcessor<V extends SpecificRecord>
             processorContext.forward(ProcessingResult.wrapRecordSuccess(message));
         } catch (Exception e) {
             processorContext.forward(ProcessingResult.wrapRecordFailure(e, message,
-                "Could not figure out what to do with the current payload: "
-                    + "An unlikely error occurred during deduplication transform"));
+                    "Could not figure out what to do with the current payload: "
+                            + "An unlikely error occurred during deduplication transform"));
         }
     }
 }

--- a/kstreamplify-core/src/main/java/com/michelin/kstreamplify/deduplication/DeduplicationUtils.java
+++ b/kstreamplify-core/src/main/java/com/michelin/kstreamplify/deduplication/DeduplicationUtils.java
@@ -2,17 +2,20 @@ package com.michelin.kstreamplify.deduplication;
 
 import com.michelin.kstreamplify.error.ProcessingResult;
 import com.michelin.kstreamplify.serde.SerdesUtils;
-import java.time.Duration;
-import java.util.function.Function;
 import lombok.NoArgsConstructor;
 import org.apache.avro.specific.SpecificRecord;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Repartitioned;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.TimestampedKeyValueStore;
 import org.apache.kafka.streams.state.WindowStore;
+
+import java.time.Duration;
+import java.util.function.Function;
 
 /**
  * Deduplication utility class. Only streams with String keys are supported.
@@ -40,11 +43,11 @@ public final class DeduplicationUtils {
      * @return KStream with a processingResult
      */
     public static <V extends SpecificRecord> KStream<String, ProcessingResult<V, V>> deduplicateKeys(
-        StreamsBuilder streamsBuilder, KStream<String, V> initialStream, Duration windowDuration) {
+            StreamsBuilder streamsBuilder, KStream<String, V> initialStream, Duration windowDuration) {
 
         return deduplicateKeys(streamsBuilder, initialStream,
-            DEFAULT_DEDUP_NAME + DEFAULT_WINDOWSTORE, DEFAULT_DEDUP_NAME + DEFAULT_REPARTITION,
-            windowDuration);
+                DEFAULT_DEDUP_NAME + DEFAULT_WINDOWSTORE, DEFAULT_DEDUP_NAME + DEFAULT_REPARTITION,
+                windowDuration);
     }
 
     /**
@@ -62,19 +65,51 @@ public final class DeduplicationUtils {
      * @return Resulting de-duplicated Stream
      */
     public static <V extends SpecificRecord> KStream<String, ProcessingResult<V, V>> deduplicateKeys(
-        StreamsBuilder streamsBuilder, KStream<String, V> initialStream, String storeName,
-        String repartitionName, Duration windowDuration) {
+            StreamsBuilder streamsBuilder, KStream<String, V> initialStream, String storeName,
+            String repartitionName, Duration windowDuration) {
+
+        return deduplicateKeys(
+                streamsBuilder, initialStream, storeName,
+                repartitionName, windowDuration, null);
+    }
+
+
+    /**
+     * Deduplicate the input stream on the input key using a window store for the given period of time.
+     *
+     * @param streamsBuilder             Stream builder instance for topology editing
+     * @param initialStream              Stream containing the events that should be deduplicated
+     * @param storeName                  State store name
+     * @param repartitionName            Repartition topic name
+     * @param windowDuration             Window of time to keep in the window store
+     * @param timestampKeyValueStoreName timestamp key value store used for state store migration
+     * @param <V>                        Generic Type of the Stream value.
+     *                                   Key type is not implemented because using anything other than
+     *                                   a String as the key is retarded.
+     *                                   You can quote me on this.
+     * @return Resulting de-duplicated Stream
+     */
+    public static <V extends SpecificRecord> KStream<String, ProcessingResult<V, V>> deduplicateKeys(
+            StreamsBuilder streamsBuilder, KStream<String, V> initialStream, String storeName,
+            String repartitionName, Duration windowDuration, String timestampKeyValueStoreName) {
 
         StoreBuilder<WindowStore<String, String>> dedupWindowStore = Stores.windowStoreBuilder(
-            Stores.persistentWindowStore(storeName, windowDuration, windowDuration, false),
-            Serdes.String(), Serdes.String());
+                Stores.persistentWindowStore(storeName, windowDuration, windowDuration, false),
+                Serdes.String(), Serdes.String());
         streamsBuilder.addStateStore(dedupWindowStore);
+        StoreBuilder<TimestampedKeyValueStore<String, String>> oldDeduplicatedStream;
+        if (!StringUtils.isEmpty(timestampKeyValueStoreName)) {
+            oldDeduplicatedStream = Stores.timestampedKeyValueStoreBuilder(
+                    Stores.persistentTimestampedKeyValueStore(timestampKeyValueStoreName),
+                    Serdes.String(), Serdes.String());
+            streamsBuilder.addStateStore(oldDeduplicatedStream);
+        }
 
         var repartitioned = initialStream.repartition(
-            Repartitioned.with(Serdes.String(), SerdesUtils.<V>getValueSerdes())
-                .withName(repartitionName));
-        return repartitioned.process(() -> new DedupKeyProcessor<>(storeName, windowDuration),
-            storeName);
+                Repartitioned.with(Serdes.String(), SerdesUtils.<V>getValueSerdes())
+                        .withName(repartitionName));
+        return repartitioned.process(() -> new DedupKeyProcessor<>(storeName, windowDuration, timestampKeyValueStoreName),
+                storeName);
     }
 
     /**
@@ -91,11 +126,11 @@ public final class DeduplicationUtils {
      * @return KStream with a processingResult
      */
     public static <V extends SpecificRecord> KStream<String, ProcessingResult<V, V>> deduplicateKeyValues(
-        StreamsBuilder streamsBuilder, KStream<String, V> initialStream, Duration windowDuration) {
+            StreamsBuilder streamsBuilder, KStream<String, V> initialStream, Duration windowDuration) {
 
         return deduplicateKeyValues(streamsBuilder, initialStream,
-            DEFAULT_DEDUP_NAME + DEFAULT_WINDOWSTORE, DEFAULT_DEDUP_NAME + DEFAULT_REPARTITION,
-            windowDuration);
+                DEFAULT_DEDUP_NAME + DEFAULT_WINDOWSTORE, DEFAULT_DEDUP_NAME + DEFAULT_REPARTITION,
+                windowDuration);
     }
 
     /**
@@ -114,19 +149,19 @@ public final class DeduplicationUtils {
      * @return Resulting de-duplicated Stream
      */
     public static <V extends SpecificRecord> KStream<String, ProcessingResult<V, V>> deduplicateKeyValues(
-        StreamsBuilder streamsBuilder, KStream<String, V> initialStream, String storeName,
-        String repartitionName, Duration windowDuration) {
+            StreamsBuilder streamsBuilder, KStream<String, V> initialStream, String storeName,
+            String repartitionName, Duration windowDuration) {
 
         StoreBuilder<WindowStore<String, V>> dedupWindowStore = Stores.windowStoreBuilder(
-            Stores.persistentWindowStore(storeName, windowDuration, windowDuration, false),
-            Serdes.String(), SerdesUtils.getValueSerdes());
+                Stores.persistentWindowStore(storeName, windowDuration, windowDuration, false),
+                Serdes.String(), SerdesUtils.getValueSerdes());
         streamsBuilder.addStateStore(dedupWindowStore);
 
         var repartitioned = initialStream.repartition(
-            Repartitioned.with(Serdes.String(), SerdesUtils.<V>getValueSerdes())
-                .withName(repartitionName));
+                Repartitioned.with(Serdes.String(), SerdesUtils.<V>getValueSerdes())
+                        .withName(repartitionName));
         return repartitioned.process(() -> new DedupKeyValueProcessor<>(storeName, windowDuration),
-            storeName);
+                storeName);
     }
 
     /**
@@ -154,11 +189,11 @@ public final class DeduplicationUtils {
      * @return Resulting de-duplicated Stream
      */
     public static <V extends SpecificRecord> KStream<String, ProcessingResult<V, V>> deduplicateWithPredicate(
-        StreamsBuilder streamsBuilder, KStream<String, V> initialStream, Duration windowDuration,
-        Function<V, String> deduplicationKeyExtractor) {
+            StreamsBuilder streamsBuilder, KStream<String, V> initialStream, Duration windowDuration,
+            Function<V, String> deduplicationKeyExtractor) {
         return deduplicateWithPredicate(streamsBuilder, initialStream,
-            DEFAULT_DEDUP_NAME + DEFAULT_WINDOWSTORE, DEFAULT_DEDUP_NAME + DEFAULT_REPARTITION,
-            windowDuration, deduplicationKeyExtractor);
+                DEFAULT_DEDUP_NAME + DEFAULT_WINDOWSTORE, DEFAULT_DEDUP_NAME + DEFAULT_REPARTITION,
+                windowDuration, deduplicationKeyExtractor);
     }
 
     /**
@@ -183,20 +218,20 @@ public final class DeduplicationUtils {
      * @return Resulting de-duplicated Stream
      */
     public static <V extends SpecificRecord> KStream<String, ProcessingResult<V, V>> deduplicateWithPredicate(
-        StreamsBuilder streamsBuilder, KStream<String, V> initialStream, String storeName,
-        String repartitionName, Duration windowDuration,
-        Function<V, String> deduplicationKeyExtractor) {
+            StreamsBuilder streamsBuilder, KStream<String, V> initialStream, String storeName,
+            String repartitionName, Duration windowDuration,
+            Function<V, String> deduplicationKeyExtractor) {
 
         StoreBuilder<WindowStore<String, V>> dedupWindowStore = Stores.windowStoreBuilder(
-            Stores.persistentWindowStore(storeName, windowDuration, windowDuration, false),
-            Serdes.String(), SerdesUtils.getValueSerdes());
+                Stores.persistentWindowStore(storeName, windowDuration, windowDuration, false),
+                Serdes.String(), SerdesUtils.getValueSerdes());
         streamsBuilder.addStateStore(dedupWindowStore);
 
         var repartitioned = initialStream.repartition(
-            Repartitioned.with(Serdes.String(), SerdesUtils.<V>getValueSerdes())
-                .withName(repartitionName));
+                Repartitioned.with(Serdes.String(), SerdesUtils.<V>getValueSerdes())
+                        .withName(repartitionName));
         return repartitioned.process(
-            () -> new DedupWithPredicateProcessor<>(storeName, windowDuration,
-                deduplicationKeyExtractor), storeName);
+                () -> new DedupWithPredicateProcessor<>(storeName, windowDuration,
+                        deduplicationKeyExtractor), storeName);
     }
 }

--- a/kstreamplify-core/src/test/java/com/michelin/kstreamplify/deduplication/DedupKeyProcessorTest.java
+++ b/kstreamplify-core/src/test/java/com/michelin/kstreamplify/deduplication/DedupKeyProcessorTest.java
@@ -1,27 +1,26 @@
 package com.michelin.kstreamplify.deduplication;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import com.michelin.kstreamplify.avro.KafkaError;
 import com.michelin.kstreamplify.error.ProcessingResult;
-import java.time.Duration;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.api.ProcessorContext;
 import org.apache.kafka.streams.processor.api.Record;
-import org.apache.kafka.streams.state.WindowStore;
-import org.apache.kafka.streams.state.WindowStoreIterator;
+import org.apache.kafka.streams.state.*;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class DedupKeyProcessorTest {
@@ -39,8 +38,8 @@ class DedupKeyProcessorTest {
 
     @BeforeEach
     void setUp() {
-        // Create an instance of DedupWithPredicateProcessor for testing
-        processor = new DedupKeyProcessor<>("testStore", Duration.ofHours(1));
+        // Create an instance of DedupKeyProcessor for testing
+        processor = new DedupKeyProcessor<>("testStore", Duration.ofHours(1), null);
 
         // Stub the context.getStateStore method to return the mock store
         when(context.getStateStore("testStore")).thenReturn(windowStore);
@@ -48,6 +47,76 @@ class DedupKeyProcessorTest {
         processor.init(context);
     }
 
+    @Test
+    void shouldNotCopyStoreWhenInit() {
+        processor.init(context);
+        verify(windowStore, never()).put(anyString(), anyString(), anyLong());
+
+    }
+
+    @Test
+    void shouldCopyStoreWhenInit() {
+        DedupKeyProcessor<KafkaError> dedupKeyProcessor = new DedupKeyProcessor<>("testStore",
+                Duration.ofHours(1), "timestampStore");
+
+        ProcessorContext<String, ProcessingResult<KafkaError, KafkaError>> processorContext = Mockito.mock(ProcessorContext.class);
+
+        WindowStore<String, String> windowStore = Mockito.mock(WindowStore.class);
+        TimestampedKeyValueStore<String, String> timestampedKeyValueStore = Mockito.mock(TimestampedKeyValueStore.class);
+
+        when(processorContext.getStateStore("testStore")).thenReturn(windowStore);
+
+        when(processorContext.getStateStore("timestampStore")).thenReturn(timestampedKeyValueStore);
+
+        long currentTimeStamp = System.currentTimeMillis();
+
+        KeyValueIterator<String, ValueAndTimestamp<String>> iterator = getStringValueAndTimestampKeyValueIterator(currentTimeStamp);
+
+        when(timestampedKeyValueStore.all()).thenReturn(iterator);
+
+        dedupKeyProcessor.init(processorContext);
+
+        verify(windowStore).put("key1", "value1", currentTimeStamp - (2 * 60 * 60 * 1000));
+        verify(windowStore).put("key2", "value2", currentTimeStamp);
+        verify(windowStore).put("key3", "value3", currentTimeStamp);
+
+        // re call the init to verify the delete part
+        dedupKeyProcessor.init(processorContext);
+        verify(windowStore).put("key1", "value1", currentTimeStamp - (2 * 60 * 60 * 1000));
+
+    }
+
+    private static @NotNull KeyValueIterator<String, ValueAndTimestamp<String>> getStringValueAndTimestampKeyValueIterator(long currentTimeStamp) {
+        List<KeyValue<String, ValueAndTimestamp<String>>> data = new ArrayList<>();
+
+        data.add(new KeyValue<>("key1", ValueAndTimestamp.make("value1", currentTimeStamp - (2 * 60 * 60 * 1000))));
+        data.add(new KeyValue<>("key2", ValueAndTimestamp.make("value2", currentTimeStamp)));
+        data.add(new KeyValue<>("key3", ValueAndTimestamp.make("value3", currentTimeStamp)));
+
+        return new KeyValueIterator<>() {
+            private final Iterator<KeyValue<String, ValueAndTimestamp<String>>> underlyingIterator = data.iterator();
+
+            @Override
+            public boolean hasNext() {
+                return underlyingIterator.hasNext();
+            }
+
+            @Override
+            public KeyValue<String, ValueAndTimestamp<String>> next() {
+                return underlyingIterator.next();
+            }
+
+            @Override
+            public void close() {
+                // nothing to do
+            }
+
+            @Override
+            public String peekNextKey() {
+                return "";
+            }
+        };
+    }
 
     @Test
     void shouldProcessNewRecord() {
@@ -87,14 +156,14 @@ class DedupKeyProcessorTest {
         Record<String, KafkaError> record = new Record<>("key", new KafkaError(), 0L);
 
         when(windowStore.backwardFetch(any(), any(), any())).thenReturn(null)
-            .thenThrow(new RuntimeException("Exception..."));
+                .thenThrow(new RuntimeException("Exception..."));
         doThrow(new RuntimeException("Exception...")).when(windowStore).put(anyString(), any(), anyLong());
 
         processor.process(record);
 
         verify(context).forward(argThat(arg -> arg.value().getError().getContextMessage()
-            .equals("Could not figure out what to do with the current payload: "
-                + "An unlikely error occurred during deduplication transform")));
+                .equals("Could not figure out what to do with the current payload: "
+                        + "An unlikely error occurred during deduplication transform")));
     }
 
 }

--- a/kstreamplify-core/src/test/java/com/michelin/kstreamplify/deduplication/DedupKeyValueProcessorTest.java
+++ b/kstreamplify-core/src/test/java/com/michelin/kstreamplify/deduplication/DedupKeyValueProcessorTest.java
@@ -39,8 +39,8 @@ class DedupKeyValueProcessorTest {
 
     @BeforeEach
     void setUp() {
-        // Create an instance of DedupWithPredicateProcessor for testing
-        processor = new DedupKeyValueProcessor<>("testStore", Duration.ofHours(1));
+        // Create an instance of DedupKeyValueProcessor for testing
+        processor = new DedupKeyValueProcessor<>("testStore", Duration.ofHours(1), null);
 
         // Stub the context.getStateStore method to return the mock store
         when(context.getStateStore("testStore")).thenReturn(windowStore);

--- a/kstreamplify-core/src/test/java/com/michelin/kstreamplify/deduplication/DedupWithPredicateProcessorTest.java
+++ b/kstreamplify-core/src/test/java/com/michelin/kstreamplify/deduplication/DedupWithPredicateProcessorTest.java
@@ -40,7 +40,7 @@ class DedupWithPredicateProcessorTest {
     @BeforeEach
     void setUp() {
         // Create an instance of DedupWithPredicateProcessor for testing
-        processor = new DedupWithPredicateProcessor<>("testStore", Duration.ofHours(1), KeyExtractorStub::extract);
+        processor = new DedupWithPredicateProcessor<>("testStore", Duration.ofHours(1), KeyExtractorStub::extract, null);
 
         // Stub the context.getStateStore method to return the mock store
         when(context.getStateStore("testStore")).thenReturn(windowStore);


### PR DESCRIPTION
In some projects, we move from dedup method that used TimestampedKeyValueStore before and now use WindowStore with Kstreamplify. 
This PR aims to do some migration from TimestampedKeyValueStore to WindowStore when using the dedup method.