### PR TITLE
Ensure topic prefixes are applied in tests with TopicWithSerde API

### DIFF
--- a/kstreamplify-core-test/src/main/java/com/michelin/kstreamplify/KafkaStreamsStarterTest.java
+++ b/kstreamplify-core-test/src/main/java/com/michelin/kstreamplify/KafkaStreamsStarterTest.java
@@ -151,7 +151,7 @@ public abstract class KafkaStreamsStarterTest {
      */
     protected <K, V> TestInputTopic<K, V> createInputTestTopic(TopicWithSerde<K, V> topicWithSerde) {
         return this.testDriver.createInputTopic(
-                topicWithSerde.getUnPrefixedName(),
+                topicWithSerde.toString(),
                 topicWithSerde.getKeySerde().serializer(),
                 topicWithSerde.getValueSerde().serializer());
     }
@@ -182,7 +182,7 @@ public abstract class KafkaStreamsStarterTest {
      */
     protected <K, V> TestOutputTopic<K, V> createOutputTestTopic(TopicWithSerde<K, V> topicWithSerde) {
         return this.testDriver.createOutputTopic(
-                topicWithSerde.getUnPrefixedName(),
+                topicWithSerde.toString(),
                 topicWithSerde.getKeySerde().deserializer(),
                 topicWithSerde.getValueSerde().deserializer());
     }

--- a/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/GetSpecificPropertiesTest.java
+++ b/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/GetSpecificPropertiesTest.java
@@ -24,10 +24,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.michelin.kstreamplify.context.KafkaStreamsExecutionContext;
 import com.michelin.kstreamplify.initializer.KafkaStreamsStarter;
+import com.michelin.kstreamplify.serde.TopicWithSerde;
 import java.util.Map;
 import java.util.Properties;
-
-import com.michelin.kstreamplify.serde.TopicWithSerde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.junit.jupiter.api.Test;
@@ -36,15 +35,9 @@ class GetSpecificPropertiesTest extends KafkaStreamsStarterTest {
     private static final String DLQ_TOPIC = "dlqTopic";
     private static final String SPECIFIC_STORAGE_PATH = "/tmp/PersonalPath";
     private static final String SPECIFIC_SCHEMA_REGISTRY_URL = "mock://specific-schema-registry-url";
-    private static final String INPUT_TOPIC = "inputTopic";
-    private static final String OUTPUT_TOPIC = "outputTopic";
-    private static final String SELF_TOPIC = "selfTopic";
-    private static final String COMMA = ",";
-    private static final String EQUALS = "=";
-    private static final String APOSTROPHE = "'";
-    private static final String EMPTY = "";
-    private static final int ZERO = 0;
-    private static final int ONE = 1;
+    private static final String INPUT_TOPIC = "INPUT_TOPIC";
+    private static final String OUTPUT_TOPIC = "OUTPUT_TOPIC";
+    private static final String SELF_TOPIC = "SELF_TOPIC";
 
     @Override
     protected KafkaStreamsStarter getKafkaStreamsStarter() {
@@ -69,11 +62,14 @@ class GetSpecificPropertiesTest extends KafkaStreamsStarterTest {
     @Override
     protected Map<String, String> getSpecificProperties() {
         return Map.of(
-                STATE_DIR_CONFIG, SPECIFIC_STORAGE_PATH,
-                SCHEMA_REGISTRY_URL_CONFIG, SPECIFIC_SCHEMA_REGISTRY_URL,
-                "prefix.abc", "abc.",
-                "prefix.def", "def."
-        );
+                STATE_DIR_CONFIG,
+                SPECIFIC_STORAGE_PATH,
+                SCHEMA_REGISTRY_URL_CONFIG,
+                SPECIFIC_SCHEMA_REGISTRY_URL,
+                "prefix.abc",
+                "abc.",
+                "prefix.def",
+                "def.");
     }
 
     /** Test when default properties are overridden. */
@@ -84,9 +80,7 @@ class GetSpecificPropertiesTest extends KafkaStreamsStarterTest {
         assertEquals(SPECIFIC_SCHEMA_REGISTRY_URL, properties.getProperty(SCHEMA_REGISTRY_URL_CONFIG));
     }
 
-    /**
-     * Test to verify that input and output topics are created with the correct prefixes.
-     */
+    /** Test to verify that input and output topics are created with the correct prefixes. */
     @Test
     void shouldCreateInputAndOutputTopicsWithPrefixes() {
         var inputTopicWithSerde = new TopicWithSerde<>(INPUT_TOPIC, "abc", Serdes.String(), Serdes.String());
@@ -97,12 +91,17 @@ class GetSpecificPropertiesTest extends KafkaStreamsStarterTest {
         var outputTopic = createOutputTestTopic(outputTopicWithSerde);
         var selfTopic = createInputTestTopic(selfTopicWithSerde);
 
-        var inputTopicName = inputTopic.toString().split(COMMA)[ZERO].split(EQUALS)[ONE].replace(APOSTROPHE, EMPTY);
-        var outputTopicName = outputTopic.toString().split(COMMA)[ZERO].split(EQUALS)[ONE].replace(APOSTROPHE, EMPTY);
-        var selfTopicName = selfTopic.toString().split(COMMA)[ZERO].split(EQUALS)[ONE].replace(APOSTROPHE, EMPTY);
-
-        assertEquals("abc.inputTopic", inputTopicName);
-        assertEquals("def.outputTopic", outputTopicName);
-        assertEquals("selfTopic", selfTopicName);
+        assertEquals(
+                "TestInputTopic[topic='abc.INPUT_TOPIC', keySerializer=StringSerializer, "
+                        + "valueSerializer=StringSerializer]",
+                inputTopic.toString());
+        assertEquals(
+                "TestOutputTopic[topic='def.OUTPUT_TOPIC', keyDeserializer=StringDeserializer, "
+                        + "valueDeserializer=StringDeserializer, size=0]",
+                outputTopic.toString());
+        assertEquals(
+                "TestInputTopic[topic='SELF_TOPIC', keySerializer=StringSerializer, "
+                        + "valueSerializer=StringSerializer]",
+                selfTopic.toString());
     }
 }


### PR DESCRIPTION
Problems it solves:  
This issue affects testing scenarios where multiple topics have the same base name but different prefixes. It leads to incorrect topic mapping and test failures when validating Kafka Streams logic.
What has been tested:
Verified that the overridden properties are correctly validated.
Confirmed that input and output topics are created with the correct prefixes.
Ensured that the refactored code maintains the same functionality and passes all existing tests. 
@loicgreffier