### PR TITLE
Add named topology support in TopicWithSerde

### DIFF
--- a/kstreamplify-core/src/main/java/com/michelin/kstreamplify/serde/TopicWithSerde.java
+++ b/kstreamplify-core/src/main/java/com/michelin/kstreamplify/serde/TopicWithSerde.java
@@ -111,6 +111,18 @@ public class TopicWithSerde<K, V> {
     }
 
     /**
+     * Wrapper for {@link StreamsBuilder#stream(String, Consumed)} with a name.
+     *
+     * @param streamsBuilder The streams builder
+     * @param name The name of the stream processor
+     * @return A ${@link KStream} from the given topic
+     */
+    public KStream<K, V> stream(StreamsBuilder streamsBuilder, String name) {
+        return streamsBuilder.stream(
+                this.toString(), Consumed.with(keySerde, valueSerde).withName(name));
+    }
+
+    /**
      * Wrapper for {@link StreamsBuilder#table(String, Consumed, Materialized)}.
      *
      * @param streamsBuilder The streams builder
@@ -121,6 +133,23 @@ public class TopicWithSerde<K, V> {
         return streamsBuilder.table(
                 this.toString(),
                 Consumed.with(keySerde, valueSerde),
+                Materialized.<K, V, KeyValueStore<Bytes, byte[]>>as(storeName)
+                        .withKeySerde(keySerde)
+                        .withValueSerde(valueSerde));
+    }
+
+    /**
+     * Wrapper for {@link StreamsBuilder#table(String, Consumed, Materialized)} with a name.
+     *
+     * @param streamsBuilder The streams builder
+     * @param storeName The store name
+     * @param name The name of the stream processor
+     * @return A ${@link KTable} from the given topic
+     */
+    public KTable<K, V> table(StreamsBuilder streamsBuilder, String storeName, String name) {
+        return streamsBuilder.table(
+                this.toString(),
+                Consumed.with(keySerde, valueSerde).withName(name),
                 Materialized.<K, V, KeyValueStore<Bytes, byte[]>>as(storeName)
                         .withKeySerde(keySerde)
                         .withValueSerde(valueSerde));
@@ -143,6 +172,23 @@ public class TopicWithSerde<K, V> {
     }
 
     /**
+     * Wrapper for {@link StreamsBuilder#globalTable(String, Consumed, Materialized)} with a name.
+     *
+     * @param streamsBuilder The streams builder
+     * @param storeName The store name
+     * @param name The name of the stream processor
+     * @return A ${@link GlobalKTable} from the given topic
+     */
+    public GlobalKTable<K, V> globalTable(StreamsBuilder streamsBuilder, String storeName, String name) {
+        return streamsBuilder.globalTable(
+                this.toString(),
+                Consumed.with(keySerde, valueSerde).withName(name),
+                Materialized.<K, V, KeyValueStore<Bytes, byte[]>>as(storeName)
+                        .withKeySerde(keySerde)
+                        .withValueSerde(valueSerde));
+    }
+
+    /**
      * Wrapper for {@link StreamsBuilder#addGlobalStore(StoreBuilder, String, Consumed, ProcessorSupplier)}.
      *
      * @param streamsBuilder The streams builder
@@ -159,11 +205,38 @@ public class TopicWithSerde<K, V> {
     }
 
     /**
+     * Wrapper for {@link StreamsBuilder#addGlobalStore(StoreBuilder, String, Consumed, ProcessorSupplier)}.
+     *
+     * @param streamsBuilder The streams builder
+     * @param storeBuilder The store builder
+     * @param processorSupplier The processor supplier
+     * @return A ${@link StreamsBuilder}
+     */
+    public StreamsBuilder addGlobalStore(
+            StreamsBuilder streamsBuilder,
+            StoreBuilder<?> storeBuilder,
+            ProcessorSupplier<K, V, Void, Void> processorSupplier,
+            String name) {
+        return streamsBuilder.addGlobalStore(
+                storeBuilder, topicName, Consumed.with(keySerde, valueSerde).withName(name), processorSupplier);
+    }
+
+    /**
      * Wrapper for {@link KStream#to(String, Produced)}.
      *
      * @param stream The stream to produce
      */
     public void produce(KStream<K, V> stream) {
         stream.to(this.toString(), Produced.with(keySerde, valueSerde));
+    }
+
+    /**
+     * Wrapper for {@link KStream#to(String, Produced)} with a name.
+     *
+     * @param stream The stream to produce
+     * @param name The name of the stream processor
+     */
+    public void produce(KStream<K, V> stream, String name) {
+        stream.to(this.toString(), Produced.with(keySerde, valueSerde).withName(name));
     }
 }

--- a/kstreamplify-core/src/test/java/com/michelin/kstreamplify/serde/TopicWithSerdeTest.java
+++ b/kstreamplify-core/src/test/java/com/michelin/kstreamplify/serde/TopicWithSerdeTest.java
@@ -75,12 +75,30 @@ class TopicWithSerdeTest {
         topicWithSerde.stream(streamsBuilder);
 
         assertEquals("""
-            Topologies:
-               Sub-topology: 0
-                Source: KSTREAM-SOURCE-0000000000 (topics: [INPUT_TOPIC])
-                  --> none
+                Topologies:
+                   Sub-topology: 0
+                    Source: KSTREAM-SOURCE-0000000000 (topics: [INPUT_TOPIC])
+                      --> none
 
-            """, streamsBuilder.build().describe().toString());
+                """, streamsBuilder.build().describe().toString());
+    }
+
+    @Test
+    void shouldCreateStreamWithName() {
+        KafkaStreamsExecutionContext.registerProperties(new Properties());
+
+        TopicWithSerde<String, String> topicWithSerde =
+                new TopicWithSerde<>("INPUT_TOPIC", Serdes.String(), Serdes.String());
+
+        StreamsBuilder streamsBuilder = new StreamsBuilder();
+        topicWithSerde.stream(streamsBuilder, "consumer-name");
+        assertEquals("""
+                Topologies:
+                   Sub-topology: 0
+                    Source: consumer-name (topics: [INPUT_TOPIC])
+                      --> none
+
+                """, streamsBuilder.build().describe().toString());
     }
 
     @Test
@@ -94,15 +112,37 @@ class TopicWithSerdeTest {
         topicWithSerde.table(streamsBuilder, "myStore");
 
         assertEquals("""
-            Topologies:
-               Sub-topology: 0
-                Source: KSTREAM-SOURCE-0000000000 (topics: [INPUT_TOPIC])
-                  --> KTABLE-SOURCE-0000000001
-                Processor: KTABLE-SOURCE-0000000001 (stores: [myStore])
-                  --> none
-                  <-- KSTREAM-SOURCE-0000000000
+                Topologies:
+                   Sub-topology: 0
+                    Source: KSTREAM-SOURCE-0000000000 (topics: [INPUT_TOPIC])
+                      --> KTABLE-SOURCE-0000000001
+                    Processor: KTABLE-SOURCE-0000000001 (stores: [myStore])
+                      --> none
+                      <-- KSTREAM-SOURCE-0000000000
 
-            """, streamsBuilder.build().describe().toString());
+                """, streamsBuilder.build().describe().toString());
+    }
+
+    @Test
+    void shouldCreateTableWithName() {
+        KafkaStreamsExecutionContext.registerProperties(new Properties());
+
+        TopicWithSerde<String, String> topicWithSerde =
+                new TopicWithSerde<>("INPUT_TOPIC", Serdes.String(), Serdes.String());
+
+        StreamsBuilder streamsBuilder = new StreamsBuilder();
+        topicWithSerde.table(streamsBuilder, "myStore", "table-processor-name");
+
+        assertEquals("""
+                Topologies:
+                   Sub-topology: 0
+                    Source: table-processor-name-source (topics: [INPUT_TOPIC])
+                      --> table-processor-name
+                    Processor: table-processor-name (stores: [myStore])
+                      --> none
+                      <-- table-processor-name-source
+
+                """, streamsBuilder.build().describe().toString());
     }
 
     @Test
@@ -116,14 +156,36 @@ class TopicWithSerdeTest {
         topicWithSerde.globalTable(streamsBuilder, "myStore");
 
         assertEquals("""
-            Topologies:
-               Sub-topology: 0 for global store (will not generate tasks)
-                Source: KSTREAM-SOURCE-0000000000 (topics: [INPUT_TOPIC])
-                  --> KTABLE-SOURCE-0000000001
-                Processor: KTABLE-SOURCE-0000000001 (stores: [myStore])
-                  --> none
-                  <-- KSTREAM-SOURCE-0000000000
-            """, streamsBuilder.build().describe().toString());
+                Topologies:
+                   Sub-topology: 0 for global store (will not generate tasks)
+                    Source: KSTREAM-SOURCE-0000000000 (topics: [INPUT_TOPIC])
+                      --> KTABLE-SOURCE-0000000001
+                    Processor: KTABLE-SOURCE-0000000001 (stores: [myStore])
+                      --> none
+                      <-- KSTREAM-SOURCE-0000000000
+                """, streamsBuilder.build().describe().toString());
+    }
+
+    @Test
+    void shouldCreateGlobalKtableWithName() {
+        KafkaStreamsExecutionContext.registerProperties(new Properties());
+
+        TopicWithSerde<String, String> topicWithSerde =
+                new TopicWithSerde<>("INPUT_TOPIC", Serdes.String(), Serdes.String());
+
+        StreamsBuilder streamsBuilder = new StreamsBuilder();
+        topicWithSerde.globalTable(streamsBuilder, "myStore", "global-table-processor-name");
+        System.out.println(streamsBuilder.build().describe());
+
+        assertEquals("""
+                Topologies:
+                   Sub-topology: 0 for global store (will not generate tasks)
+                    Source: global-table-processor-name-source (topics: [INPUT_TOPIC])
+                      --> global-table-processor-name
+                    Processor: global-table-processor-name (stores: [myStore])
+                      --> none
+                      <-- global-table-processor-name-source
+                """, streamsBuilder.build().describe().toString());
     }
 
     @Test
@@ -153,20 +215,65 @@ class TopicWithSerdeTest {
         topicUserWithSerde.addGlobalStore(streamsBuilder, timestampedStoreBuilder, MyUserProcessor::new);
 
         assertEquals("""
-            Topologies:
-               Sub-topology: 0 for global store (will not generate tasks)
-                Source: KSTREAM-SOURCE-0000000000 (topics: [INPUT_TOPIC])
-                  --> KTABLE-SOURCE-0000000001
-                Processor: KTABLE-SOURCE-0000000001 (stores: [myStore])
-                  --> none
-                  <-- KSTREAM-SOURCE-0000000000
-              Sub-topology: 1 for global store (will not generate tasks)
-                Source: KSTREAM-SOURCE-0000000002 (topics: [INPUT_USER_TOPIC])
-                  --> KTABLE-SOURCE-0000000003
-                Processor: KTABLE-SOURCE-0000000003 (stores: [myTimestampedStore])
-                  --> none
-                  <-- KSTREAM-SOURCE-0000000002
-            """, streamsBuilder.build().describe().toString());
+                Topologies:
+                   Sub-topology: 0 for global store (will not generate tasks)
+                    Source: KSTREAM-SOURCE-0000000000 (topics: [INPUT_TOPIC])
+                      --> KTABLE-SOURCE-0000000001
+                    Processor: KTABLE-SOURCE-0000000001 (stores: [myStore])
+                      --> none
+                      <-- KSTREAM-SOURCE-0000000000
+                  Sub-topology: 1 for global store (will not generate tasks)
+                    Source: KSTREAM-SOURCE-0000000002 (topics: [INPUT_USER_TOPIC])
+                      --> KTABLE-SOURCE-0000000003
+                    Processor: KTABLE-SOURCE-0000000003 (stores: [myTimestampedStore])
+                      --> none
+                      <-- KSTREAM-SOURCE-0000000002
+                """, streamsBuilder.build().describe().toString());
+    }
+
+    @Test
+    void shouldCreateGlobalStoreWithName() {
+        KafkaStreamsExecutionContext.registerProperties(new Properties());
+        KafkaStreamsExecutionContext.setSerdesConfig(
+                Collections.singletonMap(SCHEMA_REGISTRY_URL_CONFIG, "http://mock:8081"));
+
+        TopicWithSerde<String, String> topicWithSerde =
+                new TopicWithSerde<>("INPUT_TOPIC", Serdes.String(), Serdes.String());
+
+        TopicWithSerde<String, KafkaUserStub> topicUserWithSerde =
+                new TopicWithSerde<>("INPUT_USER_TOPIC", Serdes.String(), SerdesUtils.getValueSerdes());
+
+        StreamsBuilder streamsBuilder = new StreamsBuilder();
+
+        StoreBuilder<KeyValueStore<String, String>> storeBuilder = Stores.keyValueStoreBuilder(
+                Stores.persistentKeyValueStore("myStore"), Serdes.String(), Serdes.String());
+
+        StoreBuilder<TimestampedKeyValueStore<String, KafkaUserStub>> timestampedStoreBuilder =
+                Stores.timestampedKeyValueStoreBuilder(
+                        Stores.persistentTimestampedKeyValueStore("myTimestampedStore"),
+                        Serdes.String(),
+                        SerdesUtils.getValueSerdes());
+
+        topicWithSerde.addGlobalStore(
+                streamsBuilder, storeBuilder, MyStringProcessor::new, "kv-global-store-processor");
+        topicUserWithSerde.addGlobalStore(
+                streamsBuilder, timestampedStoreBuilder, MyUserProcessor::new, "timestamped-kv-global-store-processor");
+        System.out.println(streamsBuilder.build().describe());
+        assertEquals("""
+                Topologies:
+                   Sub-topology: 0 for global store (will not generate tasks)
+                    Source: kv-global-store-processor-source (topics: [INPUT_TOPIC])
+                      --> kv-global-store-processor
+                    Processor: kv-global-store-processor (stores: [myStore])
+                      --> none
+                      <-- kv-global-store-processor-source
+                  Sub-topology: 1 for global store (will not generate tasks)
+                    Source: timestamped-kv-global-store-processor-source (topics: [INPUT_USER_TOPIC])
+                      --> timestamped-kv-global-store-processor
+                    Processor: timestamped-kv-global-store-processor (stores: [myTimestampedStore])
+                      --> none
+                      <-- timestamped-kv-global-store-processor-source
+                """, streamsBuilder.build().describe().toString());
     }
 
     private static class MyStringProcessor extends ContextualProcessor<String, String, Void, Void> {


### PR DESCRIPTION
This PR extends TopicWithSerde by adding overloaded methods with a name parameter, allowing users to define explicit processor names while keeping the convenience of the abstraction.

- Added support for named operations:
stream(StreamsBuilder, String name)
table(StreamsBuilder, String storeName, String name)
globalTable(StreamsBuilder, String storeName, String name)
addGlobalStore(..., String name)
produce(KStream, String name)

Each method internally uses:

Consumed.with(...).withName(name)
Produced.with(...).withName(name)