### PR TITLE
Header-based deduplication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,6 +866,28 @@ public class MyKafkaStreams extends KafkaStreamsStarter {
 
 In the predicate approach, the provided predicate is used as the key in the window store. The stream will be deduplicated based on the values derived from the predicate.
 
+#### By Headers
+
+```java
+import java.util.List;
+
+@Component
+public class MyKafkaStreams extends KafkaStreamsStarter {
+  @Override
+  public void topology(StreamsBuilder streamsBuilder) {
+    KStream<String, KafkaUser> myStream = streamsBuilder
+            .stream("input_topic");
+
+    DeduplicationUtils
+            .deduplicateWithHeaders(streamsBuilder, myStream, Duration.ofDays(60),
+                    List.of("header1", "header2"))
+            .to("output_topic");
+  }
+}
+```
+
+The provided list of headers is used to build a composite deduplication key. The stream is deduplicated based on the extracted header values.
+
 ## OpenTelemetry
 
 Kstreamplify simplifies the integration between [OpenTelemetry](https://opentelemetry.io/) and Kafka Streams.

--- a/kstreamplify-core/src/main/java/com/michelin/kstreamplify/deduplication/DedupHeadersProcessor.java
+++ b/kstreamplify-core/src/main/java/com/michelin/kstreamplify/deduplication/DedupHeadersProcessor.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kstreamplify.deduplication;
+
+import com.michelin.kstreamplify.error.ProcessingResult;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.avro.specific.SpecificRecord;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.state.WindowStore;
+
+/**
+ * Transformer class for the deduplication mechanism on headers of a given topic.
+ *
+ * @param <V> The type of the value
+ */
+public class DedupHeadersProcessor<V extends SpecificRecord>
+        implements Processor<String, V, String, ProcessingResult<V, V>> {
+
+    /** Window store name, initialized @ construction. */
+    private final String windowStoreName;
+    /** Retention window for the state store. Used for fetching data. */
+    private final Duration retentionWindowDuration;
+    /** Deduplication headers list. */
+    private final List<String> deduplicationHeadersList;
+    /** Kstream context for this transformer. */
+    private ProcessorContext<String, ProcessingResult<V, V>> processorContext;
+    /** Window store containing all the records seen on the given window. */
+    private WindowStore<String, String> dedupWindowStore;
+
+    /**
+     * Constructor.
+     *
+     * @param windowStoreName Name of the deduplication state store
+     * @param retentionWindowDuration Retention window duration
+     * @param deduplicationHeadersList Deduplication headers list
+     */
+    public DedupHeadersProcessor(
+            String windowStoreName, Duration retentionWindowDuration, List<String> deduplicationHeadersList) {
+        this.windowStoreName = windowStoreName;
+        this.retentionWindowDuration = retentionWindowDuration;
+        this.deduplicationHeadersList = deduplicationHeadersList;
+    }
+
+    @Override
+    public void init(ProcessorContext<String, ProcessingResult<V, V>> context) {
+        this.processorContext = context;
+        dedupWindowStore = this.processorContext.getStateStore(windowStoreName);
+    }
+
+    @Override
+    public void process(Record<String, V> message) {
+        try {
+            // Get the record timestamp
+            var currentInstant = Instant.ofEpochMilli(message.timestamp());
+            String identifier = buildIdentifier(message.headers());
+
+            // Retrieve all the matching keys in the stateStore and return null if found it (signaling a duplicate)
+            try (var resultIterator = dedupWindowStore.backwardFetch(
+                    identifier,
+                    currentInstant.minus(retentionWindowDuration),
+                    currentInstant.plus(retentionWindowDuration))) {
+                while (resultIterator != null && resultIterator.hasNext()) {
+                    var currentKeyValue = resultIterator.next();
+                    if (identifier.equals(currentKeyValue.value)) {
+                        return;
+                    }
+                }
+            }
+            // First time we see this record, store entry in the window store and forward the record to the output
+            dedupWindowStore.put(identifier, identifier, message.timestamp());
+            processorContext.forward(ProcessingResult.wrapRecordSuccess(message));
+        } catch (Exception e) {
+            processorContext.forward(ProcessingResult.wrapRecordFailure(
+                    e,
+                    message,
+                    "Could not figure out what to do with the current payload: "
+                            + "An unlikely error occurred during deduplication transform"));
+        }
+    }
+
+    /**
+     * Build an identifier for the record based on the headers and the keys provided.
+     *
+     * @param headers The headers of the record
+     * @return The built identifier
+     */
+    private String buildIdentifier(Headers headers) {
+        return deduplicationHeadersList.stream()
+                .map(key -> getHeader(headers, key))
+                .collect(Collectors.joining("#"));
+    }
+
+    /**
+     * Get the header value for a given key
+     *
+     * @param headers headers of the record
+     * @param key the key to look for in the headers
+     * @return The header value for the given key, or an empty string if the header is not present or has no value.
+     */
+    private static String getHeader(Headers headers, String key) {
+        Header header = headers.lastHeader(key);
+        if (header == null || header.value() == null) {
+            return StringUtils.EMPTY;
+        }
+        String value = new String(header.value(), StandardCharsets.UTF_8);
+        return StringUtils.defaultString(value);
+    }
+}

--- a/kstreamplify-core/src/main/java/com/michelin/kstreamplify/deduplication/DeduplicationUtils.java
+++ b/kstreamplify-core/src/main/java/com/michelin/kstreamplify/deduplication/DeduplicationUtils.java
@@ -21,6 +21,7 @@ package com.michelin.kstreamplify.deduplication;
 import com.michelin.kstreamplify.error.ProcessingResult;
 import com.michelin.kstreamplify.serde.SerdesUtils;
 import java.time.Duration;
+import java.util.List;
 import java.util.function.Function;
 import org.apache.avro.specific.SpecificRecord;
 import org.apache.kafka.common.serialization.Serdes;
@@ -214,5 +215,81 @@ public final class DeduplicationUtils {
         return repartitioned.process(
                 () -> new DedupWithPredicateProcessor<>(storeName, windowDuration, deduplicationKeyExtractor),
                 storeName);
+    }
+
+    /**
+     * Deduplicates records from the input stream based on a computed key derived from each record.
+     *
+     * <p>The provided {@code deduplicationHeadersExtractor} generates a list of String values that together form a
+     * unique identifier for a record. Records with the same identifier within the given time window are considered
+     * duplicates.
+     *
+     * <p>A window store is used to track seen identifiers for the specified {@code windowDuration}.
+     *
+     * <p><b>Note:</b> This method uses internally generated store and repartition names. It should not be used multiple
+     * times in the same topology. In such cases, use {@link DeduplicationUtils#deduplicateWithHeaders(StreamsBuilder,
+     * KStream, String, String, Duration, Function)}.
+     *
+     * @param streamsBuilder the {@link StreamsBuilder} used to build the topology
+     * @param initialStream the input stream to deduplicate (must have String keys)
+     * @param windowDuration the time window during which duplicates are filtered
+     * @param deduplicationHeadersList list of header names to extract from each record for deduplication. The
+     *     combination of these header values forms the unique identifier for deduplication.
+     * @param <V> the value type of the stream
+     * @return a deduplicated stream containing {@link ProcessingResult}
+     */
+    public static <V extends SpecificRecord> KStream<String, ProcessingResult<V, V>> deduplicateWithHeaders(
+            StreamsBuilder streamsBuilder,
+            KStream<String, V> initialStream,
+            Duration windowDuration,
+            List<String> deduplicationHeadersList) {
+
+        return deduplicateWithHeaders(
+                streamsBuilder,
+                initialStream,
+                DEFAULT_DEDUP_NAME + DEFAULT_WINDOWSTORE,
+                DEFAULT_DEDUP_NAME + DEFAULT_REPARTITION,
+                windowDuration,
+                deduplicationHeadersList);
+    }
+
+    /**
+     * Deduplicates records from the input stream based on a computed key derived from each record.
+     *
+     * <p>The {@code deduplicationHeadersExtractor} produces a list of String values used to build a unique identifier
+     * for each record. Records sharing the same identifier within the configured time window are considered duplicates.
+     *
+     * <p>This variant allows specifying custom state store and repartition names, making it suitable for reuse within
+     * the same topology.
+     *
+     * @param streamsBuilder the {@link StreamsBuilder} used to build the topology
+     * @param initialStream the input stream to deduplicate (must have String keys)
+     * @param storeName the name of the state store used for deduplication
+     * @param repartitionName the name of the repartition topic
+     * @param windowDuration the time window during which duplicates are filtered
+     * @param deduplicationHeadersList list of header names to extract from each record for deduplication. The
+     *     combination of these header values forms the unique identifier for deduplication.
+     * @param <V> the value type of the stream
+     * @return a deduplicated stream containing {@link ProcessingResult}
+     */
+    public static <V extends SpecificRecord> KStream<String, ProcessingResult<V, V>> deduplicateWithHeaders(
+            StreamsBuilder streamsBuilder,
+            KStream<String, V> initialStream,
+            String storeName,
+            String repartitionName,
+            Duration windowDuration,
+            List<String> deduplicationHeadersList) {
+
+        StoreBuilder<WindowStore<String, String>> dedupWindowStore = Stores.windowStoreBuilder(
+                Stores.persistentWindowStore(storeName, windowDuration, windowDuration, false),
+                Serdes.String(),
+                Serdes.String());
+        streamsBuilder.addStateStore(dedupWindowStore);
+
+        var repartitioned =
+                initialStream.repartition(Repartitioned.with(Serdes.String(), SerdesUtils.<V>getValueSerdes())
+                        .withName(repartitionName));
+        return repartitioned.process(
+                () -> new DedupHeadersProcessor<>(storeName, windowDuration, deduplicationHeadersList), storeName);
     }
 }

--- a/kstreamplify-core/src/main/java/com/michelin/kstreamplify/deduplication/DeduplicationUtils.java
+++ b/kstreamplify-core/src/main/java/com/michelin/kstreamplify/deduplication/DeduplicationUtils.java
@@ -228,7 +228,7 @@ public final class DeduplicationUtils {
      *
      * <p><b>Note:</b> This method uses internally generated store and repartition names. It should not be used multiple
      * times in the same topology. In such cases, use {@link DeduplicationUtils#deduplicateWithHeaders(StreamsBuilder,
-     * KStream, String, String, Duration, Function)}.
+     * KStream, String, String, Duration, List)}.
      *
      * @param streamsBuilder the {@link StreamsBuilder} used to build the topology
      * @param initialStream the input stream to deduplicate (must have String keys)

--- a/kstreamplify-core/src/test/java/com/michelin/kstreamplify/deduplication/DedupHeadersProcessorTest.java
+++ b/kstreamplify-core/src/test/java/com/michelin/kstreamplify/deduplication/DedupHeadersProcessorTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kstreamplify.deduplication;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.michelin.kstreamplify.avro.KafkaError;
+import com.michelin.kstreamplify.error.ProcessingResult;
+import java.time.Duration;
+import java.util.List;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.state.WindowStore;
+import org.apache.kafka.streams.state.WindowStoreIterator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DedupHeadersProcessorTest {
+
+    private DedupHeadersProcessor<KafkaError> processor;
+
+    @Mock
+    private ProcessorContext<String, ProcessingResult<KafkaError, KafkaError>> context;
+
+    @Mock
+    private WindowStore<String, String> windowStore;
+
+    @Mock
+    private WindowStoreIterator<String> windowStoreIterator;
+
+    @BeforeEach
+    void setUp() {
+        // Create an instance of DedupWithHeadersProcessor for testing
+        processor = new DedupHeadersProcessor<>("testStore", Duration.ofHours(1), List.of("header-1", "header-3"));
+        // Stub the context.getStateStore method to return the mock store
+        when(context.getStateStore("testStore")).thenReturn(windowStore);
+
+        processor.init(context);
+    }
+
+    @Test
+    void shouldProcessNewRecord() {
+        final KafkaError kafkaError = new KafkaError();
+        final Record<String, KafkaError> message = new Record<>("key", kafkaError, 0);
+        message.headers().add("header-1", "value-1".getBytes());
+        message.headers().add("header-2", "value-2".getBytes());
+        message.headers().add("header-3", "value-3".getBytes());
+        processor.process(message);
+
+        verify(windowStore).put("value-1#value-3", "value-1#value-3", message.timestamp());
+        verify(context).forward(argThat(arg -> arg.value().getValue().equals(message.value())));
+    }
+
+    @Test
+    void shouldProcessDuplicate() {
+        final KafkaError kafkaError = new KafkaError();
+        final Record<String, KafkaError> message = new Record<>("key", kafkaError, 0);
+        message.headers().add("header-1", "value-1".getBytes());
+        message.headers().add("header-2", "value-2".getBytes());
+        message.headers().add("header-3", "value-3".getBytes());
+
+        // Simulate hasNext() returning true once and then false
+        when(windowStoreIterator.hasNext()).thenReturn(true);
+
+        // Simulate the condition to trigger the return statement
+        when(windowStoreIterator.next()).thenReturn(KeyValue.pair(0L, "value-1#value-3"));
+
+        // Simulate the backwardFetch() method returning the mocked ResultIterator
+        when(windowStore.backwardFetch(any(), any(), any())).thenReturn(windowStoreIterator);
+
+        // Call the process method
+        processor.process(message);
+
+        verify(windowStore, never()).put(anyString(), any(), anyLong());
+        verify(context, never()).forward(any());
+    }
+
+    @Test
+    void shouldThrowException() {
+        Record<String, KafkaError> message = new Record<>("key", new KafkaError(), 0L);
+        message.headers().add("header-1", "value-1".getBytes());
+        message.headers().add("header-2", "value-2".getBytes());
+        message.headers().add("header-3", "value-3".getBytes());
+
+        when(windowStore.backwardFetch(any(), any(), any()))
+                .thenReturn(null)
+                .thenThrow(new RuntimeException("Exception..."));
+        doThrow(new RuntimeException("Exception...")).when(windowStore).put(anyString(), any(), anyLong());
+
+        processor.process(message);
+
+        verify(context).forward(argThat(arg -> arg.value()
+                .getError()
+                .getContextMessage()
+                .equals("Could not figure out what to do with the current payload: "
+                        + "An unlikely error occurred during deduplication transform")));
+    }
+}


### PR DESCRIPTION
📌 Overview

This PR introduces a new deduplication capability based on record headers, allowing stream records to be deduplicated using a composite key built from a configurable list of header names.

✨ New Feature
Added deduplicateWithHeaders support in DeduplicationUtils
Allows users to define a list of header keys used to build a composite deduplication key
Records are deduplicated within a configurable time window
Works consistently with existing deduplication strategies (keys and key/value based)

⚙️ Behavior
The provided list of headers is used to extract values from each record
These values are concatenated internally to form a composite deduplication key
Records with identical composite keys within the retention window are considered duplicates and filtered out

🔄 Consistency

This feature aligns with existing deduplication strategies:

deduplicateKeys → based on Kafka record key
deduplicateKeyValues → based on key + value
deduplicateWithPredicate → based on extracted key function
deduplicateWithHeaders → based on selected headers