### PR TITLE
Scan GitHub Actions workflows with zizmor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
       day: "monday"
     labels:
       - "dependencies"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -19,3 +21,5 @@ updates:
       day: "monday"
     labels:
       - "dependencies"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,17 +13,21 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     strategy:
       matrix:
         java: [ '17', '21', '25' ]
     steps:
       - name: Checkout project
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -35,14 +39,14 @@ jobs:
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Cache SonarQube packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
       - name: Cache Maven packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -56,7 +60,7 @@ jobs:
 
       - name: Publish test report
         if: always()
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 # v6
         with:
           report_paths: '**/target/surefire-reports/TEST-*.xml'
 

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -12,16 +12,21 @@ jobs:
     name: Create Branch
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
     steps:
       - name: Checkout project
-        uses: actions/checkout@v7
+        # zizmor: ignore[artipacked] persisted credentials are required to push the hotfix branch below
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
           token: ${{ secrets.CI_CD_TOKEN }}
 
       - name: Create branch
+        env:
+          TAG_VERSION: ${{ github.event.inputs.tag_version }}
         run: |
-          START_TAG=v${{ github.event.inputs.tag_version }}
+          START_TAG=v$TAG_VERSION
           echo "Start from tag $START_TAG"
           MAJOR_MINOR_DIGIT=$(echo "$START_TAG" | cut -d '.' -f 1-2)
           PATCH_DIGIT=$(echo "$START_TAG" | cut -d '.' -f 3)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,28 +9,25 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
       - name: Checkout project
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: maven
           server-id: central
           server-username: SONATYPE_USERNAME
           server-password: SONATYPE_TOKEN
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
-
-      - name: Cache Maven packages
-        uses: actions/cache@v6
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
 
       - name: Deploy
         run: mvn -B clean deploy -DskipTests -Psign
@@ -40,7 +37,7 @@ jobs:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Generate release changelog
-        uses: mikepenz/release-changelog-builder-action@v6
+        uses: mikepenz/release-changelog-builder-action@c9bcd8238b6f41e05561348339429d360b1c0247 # v6
         id: build_changelog
         with:
           configuration: 'changelog-builder.json'
@@ -48,7 +45,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create release
-        uses: ncipollo/release-action@v1.21.0
+        # zizmor: ignore[superfluous-actions] ncipollo/release-action provides allowUpdates semantics that gh release cannot replicate in a single command
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: ${{ steps.build_changelog.outputs.changelog }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create release
-        # zizmor: ignore[superfluous-actions] ncipollo/release-action provides allowUpdates semantics that gh release cannot replicate in a single command
-        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
+        # ncipollo/release-action v1.21.0 (pinned by SHA). Kept over `gh release` for its
+        # allowUpdates support, which has no single-command equivalent.
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # zizmor: ignore[superfluous-actions]
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: ${{ steps.build_changelog.outputs.changelog }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,14 +9,18 @@ jobs:
   scan-code:
     name: Scan code
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout project
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Trivy source code
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scan-ref: .
@@ -29,7 +33,7 @@ jobs:
 
       - name: Upload Trivy source code report
         if: always()
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: trivy-results.sarif
           category: source-code

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -12,21 +12,24 @@ jobs:
     name: Tag
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/hotfix/v')
+    permissions:
+      contents: read
     steps:
       - name: Checkout project
-        uses: actions/checkout@v7
+        # zizmor: ignore[artipacked] persisted credentials are required to push the release commit and tag below
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           token: ${{ secrets.CI_CD_TOKEN }}
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: maven
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v7
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
@@ -34,24 +37,28 @@ jobs:
           git_commit_gpgsign: true
 
       - name: Validate release version format
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.release_version }}
         run: |
-          if [[ ! "${{ github.event.inputs.release_version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Release version must follow SemVer format (X.Y.Z) and start with a digit"
-            echo "Current value: ${{ github.event.inputs.release_version }}"
+            echo "Current value: $RELEASE_VERSION"
             echo "Expected format: 1.2.3, 2.0.0, etc."
             echo "Note: The 'v' prefix will be added automatically to the tag. Do not include it manually"
             exit 1
           fi
 
       - name: Create tag
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.release_version }}
         run: |
-          mvn versions:set -DnewVersion=${{ github.event.inputs.release_version }}
+          mvn versions:set -DnewVersion="$RELEASE_VERSION"
           git add pom.xml
           git add **/pom.xml
-          git commit -s -m "Prepare release v${{ github.event.inputs.release_version }}"
+          git commit -s -m "Prepare release v$RELEASE_VERSION"
           git push
-          git tag v${{ github.event.inputs.release_version }} -s -m "Create tag v${{ github.event.inputs.release_version }}"
-          git push origin v${{ github.event.inputs.release_version }}
+          git tag "v$RELEASE_VERSION" -s -m "Create tag v$RELEASE_VERSION"
+          git push origin "v$RELEASE_VERSION"
 
       - name: Update next version
         run: |

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -25,4 +25,4 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,28 @@
+name: zizmor
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  schedule:
+    - cron: '0 5 * * 1'
+  workflow_dispatch:
+
+jobs:
+  scan-actions:
+    name: Scan GitHub Actions
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@v0.5.3

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -20,9 +20,9 @@ jobs:
       security-events: write
     steps:
       - name: Checkout project
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@v0.5.3
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3


### PR DESCRIPTION
Closes #525

## What

Adds a `zizmor` workflow that statically audits our GitHub Actions for
supply-chain and misconfiguration issues (unpinned actions, overbroad token
scopes, template-injection sinks, credential persistence) and uploads SARIF to
the Security tab, mirroring how Trivy scans source code.

To land the scan green, this PR also remediates every finding zizmor reports
across the existing workflows.

## Changes

**New**
- `.github/workflows/zizmor.yml`: runs `zizmorcore/zizmor-action` on PRs
  touching `.github/workflows/**`, on push to `main`, weekly, and via
  `workflow_dispatch`. SARIF goes to the Security tab.

**Hardening of existing workflows**
- Pinned every action to a full commit SHA (`unpinned-uses`)
- Added least-privilege `permissions:` blocks to every job (`excessive-permissions`)
- Moved `workflow_dispatch` inputs into `env:` vars in `run:` steps to prevent
  shell injection (`template-injection` in `hotfix.yml` and `tag.yml`)
- Set `persist-credentials: false` on read-only checkouts (`artipacked`)
- Removed Maven caching from `release.yml`, since a publish pipeline shouldn't
  restore a potentially poisoned cache (`cache-poisoning`)
- Added a 7-day Dependabot `cooldown` for the maven and github-actions
  ecosystems (`dependabot-cooldown`)

## Accepted findings (documented inline via `# zizmor: ignore[...]`)

- `artipacked` on the `hotfix.yml` and `tag.yml` checkouts: persisted
  credentials are required to push the branch, tag, and commit.
- `superfluous-actions` on `ncipollo/release-action`: kept for its
  `allowUpdates` support, which `gh release` can't replicate in one command.

## Notes

- The zizmor CLI version follows the action pin (`v0.5.7` ships zizmor
  `1.26.1`); Dependabot will bump it going forward.
- Local `zizmor 1.26.1` over the repo reports **No findings** (3 ignored,
  29 suppressed).
