### PR TITLE
Support handleSerializationError in DlqProductionExceptionHandler for…

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,20 @@ kafka:
 
 It routes a [`KafkaError`](#avro-kafka-error) Avro object to the DLQ topic.
 
+Additionally, serialization exceptions can optionally be forwarded to the DLQ by enabling the following property:
+
+```yml
+kafka:
+  properties:
+    dlq:
+      production-handler:
+        continue-on-serialization-exception: true
+```
+
+| Property                                                             | Description                                                                                              |
+|----------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
+| `dlq.production-handler.continue-on-serialization-exception`         | Routes serialization errors to the DLQ and continues processing instead of failing the application       |
+
 ### Avro Kafka Error
 
 A `KafkaError` Avro object is sent to the DLQ topic for each failed record.

--- a/kstreamplify-core/src/main/java/com/michelin/kstreamplify/error/DlqProductionExceptionHandler.java
+++ b/kstreamplify-core/src/main/java/com/michelin/kstreamplify/error/DlqProductionExceptionHandler.java
@@ -18,6 +18,7 @@
  */
 package com.michelin.kstreamplify.error;
 
+import static com.michelin.kstreamplify.property.KstreamplifyConfig.DLQ_PRODUCTION_HANDLER_CONTINUE_ON_SERIALIZATION_EXCEPTION;
 import static org.apache.kafka.streams.StreamsConfig.APPLICATION_ID_CONFIG;
 
 import com.michelin.kstreamplify.avro.KafkaError;
@@ -32,13 +33,27 @@ import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.errors.ErrorHandlerContext;
 import org.apache.kafka.streams.errors.ProductionExceptionHandler;
 
-/** The class managing DLQ production exceptions. */
+/**
+ * Production exception handler that routes failed records to a Dead Letter Queue (DLQ) topic. Handles both general
+ * production errors and serialization errors by wrapping failed records in a {@link KafkaError} and sending them to the
+ * configured DLQ topic.
+ */
 @Slf4j
 public class DlqProductionExceptionHandler extends DlqExceptionHandler implements ProductionExceptionHandler {
+    private boolean continueOnSerializationException;
 
     /** Constructor. */
     public DlqProductionExceptionHandler() {}
 
+    /**
+     * Handles production exceptions by routing failed records to the DLQ topic. Returns FAIL if no DLQ is configured,
+     * RETRY for retriable exceptions, or RESUME after sending to DLQ.
+     *
+     * @param context the error handler context with metadata about the error
+     * @param producerRecord the producer record that failed to be produced
+     * @param exception the exception that occurred during production
+     * @return a {@link Response} indicating how to proceed (FAIL, RETRY, or RESUME)
+     */
     @Override
     public Response handleError(
             ErrorHandlerContext context, ProducerRecord<byte[], byte[]> producerRecord, Exception exception) {
@@ -88,9 +103,80 @@ public class DlqProductionExceptionHandler extends DlqExceptionHandler implement
         }
     }
 
-    /** {@inheritDoc} */
+    /**
+     * Handles serialization exceptions by routing failed records with raw bytes to the DLQ topic. Behavior is
+     * controlled by the {@code continueOnSerializationException} flag. Returns FAIL if the flag is disabled or no DLQ
+     * is configured, otherwise RESUME after sending to DLQ.
+     *
+     * @param context the error handler context with access to source raw bytes
+     * @param record the producer record that failed serialization
+     * @param exception the serialization exception that occurred
+     * @param origin the origin of the serialization exception (KEY or VALUE)
+     * @return a {@link Response} indicating how to proceed (FAIL or RESUME)
+     */
+    @Override
+    public Response handleSerializationError(
+            ErrorHandlerContext context,
+            ProducerRecord record,
+            Exception exception,
+            SerializationExceptionOrigin origin) {
+        log.warn(
+                "Serialization exception during message Production, origin: {}, processor node: {}, taskId: {}, source topic: {}, source partition: {}, source offset: {}",
+                origin,
+                context.processorNodeId(),
+                context.taskId(),
+                context.topic(),
+                context.partition(),
+                context.offset(),
+                exception);
+
+        if (!continueOnSerializationException) {
+            return Response.fail();
+        }
+
+        if (isDlqNotDefined()) {
+            log.warn("Failed to route serialization error to DLQ. Define a DLQ topic in configuration.");
+            return Response.fail();
+        }
+
+        try {
+            KafkaError.Builder builder = KafkaError.newBuilder()
+                    .setContextMessage("A serialization exception occurred during the stream internal production. "
+                            + "Origin: " + origin + ". "
+                            + "Please find more details about the exception in the cause and stack fields.")
+                    .setOffset(context.offset())
+                    .setPartition(context.partition())
+                    .setTopic(record.topic())
+                    .setApplicationId(
+                            KafkaStreamsExecutionContext.getProperties().getProperty(APPLICATION_ID_CONFIG))
+                    .setProcessorNodeId(context.processorNodeId())
+                    .setTaskId(context.taskId().toString());
+
+            KafkaError error = enrichWithException(builder, exception, context.sourceRawKey(), context.sourceRawValue())
+                    .build();
+
+            Serde<KafkaError> serde = SerdesUtils.getValueSerdes();
+            byte[] value = serde.serializer().serialize(deadLetterQueueTopic, error);
+
+            return Response.resume(List.of(new ProducerRecord<>(deadLetterQueueTopic, context.sourceRawKey(), value)));
+        } catch (Exception e) {
+            log.error(
+                    "Cannot send serialization exception to DLQ topic {}",
+                    KafkaStreamsExecutionContext.getDlqTopicName(),
+                    e);
+            return Response.resume();
+        }
+    }
+
+    /**
+     * Configures the handler with DLQ topic name and serialization exception handling flag.
+     *
+     * @param configs the configuration map provided by Kafka Streams
+     */
     @Override
     public void configure(Map<String, ?> configs) {
         deadLetterQueueTopic = KafkaStreamsExecutionContext.getDlqTopicName();
+        continueOnSerializationException = KafkaStreamsExecutionContext.isDlqFeatureEnabled(
+                DLQ_PRODUCTION_HANDLER_CONTINUE_ON_SERIALIZATION_EXCEPTION);
     }
 }

--- a/kstreamplify-core/src/main/java/com/michelin/kstreamplify/property/KstreamplifyConfig.java
+++ b/kstreamplify-core/src/main/java/com/michelin/kstreamplify/property/KstreamplifyConfig.java
@@ -30,6 +30,10 @@ public abstract class KstreamplifyConfig {
     public static final String DLQ_DESERIALIZATION_HANDLER_CONTINUE_ON_UNHANDLED_ERRORS =
             "dlq.deserialization-handler.continue-on-unhandled-errors";
 
+    /** Property key to configure handling of serialization exceptions in DLQ production handler. */
+    public static final String DLQ_PRODUCTION_HANDLER_CONTINUE_ON_SERIALIZATION_EXCEPTION =
+            "dlq.production-handler.continue-on-serialization-exception";
+
     /** Constructor. */
     private KstreamplifyConfig() {}
 }

--- a/kstreamplify-core/src/test/java/com/michelin/kstreamplify/error/DlqProductionExceptionHandlerTest.java
+++ b/kstreamplify-core/src/test/java/com/michelin/kstreamplify/error/DlqProductionExceptionHandlerTest.java
@@ -37,6 +37,7 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.errors.ErrorHandlerContext;
 import org.apache.kafka.streams.errors.ProductionExceptionHandler;
+import org.apache.kafka.streams.errors.ProductionExceptionHandler.SerializationExceptionOrigin;
 import org.apache.kafka.streams.processor.TaskId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -137,6 +138,120 @@ class DlqProductionExceptionHandlerTest {
                 errorHandlerContext, producerRecord, new RetriableCommitFailedException("Exception..."));
 
         assertEquals(ProductionExceptionHandler.Result.RETRY, response.result());
+        assertTrue(response.deadLetterQueueRecords().isEmpty());
+    }
+
+    @Test
+    void shouldReturnFailOnSerializationErrorWhenFlagDisabled() {
+        DlqProductionExceptionHandler handler = new DlqProductionExceptionHandler();
+        KafkaStreamsExecutionContext.setDlqTopicName("DLQ_TOPIC");
+        handler.configure(Map.of());
+
+        @SuppressWarnings("rawtypes")
+        ProducerRecord rawRecord = new ProducerRecord<>("topic", "key", "value");
+
+        ProductionExceptionHandler.Response response = handler.handleSerializationError(
+                errorHandlerContext,
+                rawRecord,
+                new RuntimeException("Serialization failed"),
+                SerializationExceptionOrigin.VALUE);
+
+        assertEquals(ProductionExceptionHandler.Result.FAIL, response.result());
+        assertTrue(response.deadLetterQueueRecords().isEmpty());
+    }
+
+    @Test
+    void shouldReturnFailOnSerializationErrorWhenFlagEnabledButNoDlq() {
+        Properties properties = new Properties();
+        properties.setProperty(APPLICATION_ID_CONFIG, "test-app");
+        properties.setProperty(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "mock://");
+        properties.setProperty("dlq.production-handler.continue-on-serialization-exception", "true");
+        KafkaStreamsExecutionContext.registerProperties(properties);
+
+        DlqProductionExceptionHandler handler = new DlqProductionExceptionHandler();
+        handler.configure(Map.of());
+
+        @SuppressWarnings("rawtypes")
+        ProducerRecord rawRecord = new ProducerRecord<>("topic", "key", "value");
+
+        ProductionExceptionHandler.Response response = handler.handleSerializationError(
+                errorHandlerContext,
+                rawRecord,
+                new RuntimeException("Serialization failed"),
+                SerializationExceptionOrigin.VALUE);
+
+        assertEquals(ProductionExceptionHandler.Result.FAIL, response.result());
+        assertTrue(response.deadLetterQueueRecords().isEmpty());
+    }
+
+    @Test
+    void shouldRouteSerializationErrorToDlqWhenFlagEnabled() {
+        Properties properties = new Properties();
+        properties.setProperty(APPLICATION_ID_CONFIG, "test-app");
+        properties.setProperty(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "mock://");
+        properties.setProperty("dlq.production-handler.continue-on-serialization-exception", "true");
+        KafkaStreamsExecutionContext.registerProperties(properties);
+        KafkaStreamsExecutionContext.setDlqTopicName("DLQ_TOPIC");
+        KafkaStreamsExecutionContext.setSerdesConfig(
+                Map.of(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "mock://"));
+
+        DlqProductionExceptionHandler handler = new DlqProductionExceptionHandler();
+        handler.configure(Map.of());
+
+        when(errorHandlerContext.taskId()).thenReturn(new TaskId(0, 0));
+        when(errorHandlerContext.partition()).thenReturn(0);
+        when(errorHandlerContext.sourceRawKey()).thenReturn("key".getBytes(StandardCharsets.UTF_8));
+        when(errorHandlerContext.sourceRawValue()).thenReturn("value".getBytes(StandardCharsets.UTF_8));
+
+        @SuppressWarnings("rawtypes")
+        ProducerRecord rawRecord = new ProducerRecord<>("topic", "key", "value");
+
+        Exception wrapped = new Exception("Wrapper", new KafkaException("Serialization failed"));
+
+        ProductionExceptionHandler.Response response = handler.handleSerializationError(
+                errorHandlerContext, rawRecord, wrapped, SerializationExceptionOrigin.VALUE);
+
+        assertEquals(ProductionExceptionHandler.Result.RESUME, response.result());
+
+        Serde<KafkaError> serde = SerdesUtils.getValueSerdes();
+        KafkaError kafkaError = serde.deserializer()
+                .deserialize(
+                        "DLQ_TOPIC", response.deadLetterQueueRecords().get(0).value());
+
+        assertTrue(kafkaError.getContextMessage().contains("serialization exception"));
+        assertTrue(kafkaError.getContextMessage().contains("VALUE"));
+        assertEquals(0, kafkaError.getOffset());
+        assertEquals(0, kafkaError.getPartition());
+        assertEquals("topic", kafkaError.getTopic());
+        assertEquals("test-app", kafkaError.getApplicationId());
+        assertEquals("0_0", kafkaError.getTaskId());
+        assertEquals("Serialization failed", kafkaError.getCause());
+        assertTrue(kafkaError.getStack().contains("Serialization failed"));
+        assertEquals("key", new String(response.deadLetterQueueRecords().get(0).key()));
+    }
+
+    @Test
+    void shouldReturnResumeOnExceptionDuringSerializationErrorHandling() {
+        Properties properties = new Properties();
+        properties.setProperty(APPLICATION_ID_CONFIG, "test-app");
+        properties.setProperty(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "mock://");
+        properties.setProperty("dlq.production-handler.continue-on-serialization-exception", "true");
+        KafkaStreamsExecutionContext.registerProperties(properties);
+        KafkaStreamsExecutionContext.setDlqTopicName("DLQ_TOPIC");
+
+        DlqProductionExceptionHandler handler = new DlqProductionExceptionHandler();
+        handler.configure(Map.of());
+
+        @SuppressWarnings("rawtypes")
+        ProducerRecord rawRecord = new ProducerRecord<>("topic", "key", "value");
+
+        ProductionExceptionHandler.Response response = handler.handleSerializationError(
+                errorHandlerContext,
+                rawRecord,
+                new KafkaException("Serialization failed"),
+                SerializationExceptionOrigin.KEY);
+
+        assertEquals(ProductionExceptionHandler.Result.RESUME, response.result());
         assertTrue(response.deadLetterQueueRecords().isEmpty());
     }
 }

--- a/kstreamplify-core/src/test/resources/application.yml
+++ b/kstreamplify-core/src/test/resources/application.yml
@@ -9,5 +9,7 @@ kafka:
       deserialization-handler:
         forward-restclient-exception: true
         continue-on-unhandled-errors: true
+      production-handler:
+        continue-on-serialization-exception: true
 server:
   port: 8080


### PR DESCRIPTION
#524 

Summary

Overriden handleSerializationError() in DlqProductionExceptionHandler so that serialization exceptions (e.g., poison pill records) can optionally be routed to the DLQ instead of crashing the application.

Changes

- DlqProductionExceptionHandler – Implemented handleSerializationError() with opt-in DLQ routing controlled by a new config flag. Added JavaDoc to all methods.
- KstreamplifyConfig – Added dlq.production-handler.continue-on-serialization-exception property constant.
- DlqProductionExceptionHandlerTest – Added 4 tests covering: flag disabled → FAIL, flag enabled but no DLQ → FAIL, flag enabled with DLQ → RESUME + record in DLQ, internal error during handling → RESUME.
- application.yml / README.md – Documented the new configuration property.

```yml
kafka:
  properties:
    dlq:
      production-handler:
        continue-on-serialization-exception: true
```