### PR TITLE
#558 Fluent and type-safe testing DSL for kstreamplify-core-test

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Kstreamplify adds extra features to Kafka Streams, simplifying development so yo
   * [Java](#java)
   * [Unit Test](#unit-test)
     * [Override Properties](#override-properties)
+    * [Fluent Testing DSL](#fluent-testing-dsl)
 * [Avro Serializer and Deserializer](#avro-serializer-and-deserializer)
 * [Error Handling](#error-handling)
   * [Set up DLQ Topic](#set-up-dlq-topic)
@@ -268,6 +269,143 @@ public class MyKafkaStreamsTest extends KafkaStreamsStarterTest {
     }
 }
 ```
+
+#### Fluent Testing DSL
+
+`KafkaStreamsStarterTest` also provides a fluent, type-safe `Given → When → Then` DSL through the `test()` method. It
+is built on top of the same Topology Test Driver infrastructure and reuses your `TopicWithSerde` declarations, so you no
+longer need to create `TestInputTopic`/`TestOutputTopic` instances or read records manually.
+
+The following test pipes a record and asserts the output:
+
+```java
+@Test
+void shouldUpperCase() {
+    test()
+        .given(inputTopic)
+        .record("1", inputValue)
+        .when()
+        .then(outputTopic)
+        .hasExactly(1)
+        .containsKey("1")
+        .satisfies(record -> assertEquals(expectedOutputValue, record.value()));
+}
+```
+
+Feed multiple input topics (useful for joins and enrichment) with `and(...)`, and pipe several records or a bulk
+collection:
+
+```java
+test()
+    .given(inputTopic)
+    .record("1", firstInputValue)
+    .record("2", secondInputValue)
+    .records(List.of(KeyValue.pair("3", thirdInputValue)))
+    .and(secondInputTopic)
+    .record("1", otherInputValue)
+    .when()
+    .then(outputTopic)
+    .hasExactly(3);
+```
+
+The available output assertions are `hasExactly(...)`, `isEmpty()`, `containsKey(...)`, `doesNotContainKey(...)`,
+`containsRecord(...)`, `containsValue(...)`, `containsHeader(...)`, `containsExactly(...)`, `satisfies(...)`,
+`satisfies(index, ...)` and `allSatisfy(...)`:
+
+```java
+test()
+    .given(inputTopic)
+    .record("1", inputValue)
+    .when()
+    .then(outputTopic)
+    .containsExactly(Map.entry("1", expectedOutputValue))
+    .containsValue(expectedOutputValue::equals)
+    .containsHeader("correlation-id", "CORRELATION-1")
+    .allSatisfy(record -> assertNotNull(record.value()));
+```
+
+Assert dead letter queue (DLQ) records without reading the DLQ topic yourself. The internal `KafkaError`
+representation is hidden behind `DlqRecord`:
+
+```java
+test()
+    .given(inputTopic)
+    .record("1", invalidInputValue)
+    .when()
+    .thenDlq()
+    .hasExactly(1)
+    .containsKey("1")
+    .containsError(IllegalStateException.class, "Invalid value")
+    .containsHeader("correlation-id", "CORRELATION-1")
+    .satisfies(error -> {
+        assertEquals("1", error.key());
+        assertEquals("java.lang.IllegalStateException", error.exceptionTypeName());
+        assertEquals("Invalid value", error.errorMessage());
+    });
+```
+
+Assert the content of a state store:
+
+```java
+test()
+    .given(inputTopic)
+    .record("1", inputValue)
+    .when()
+    .thenStateStore("my-store")
+    .hasExactly(1)
+    .contains("1", inputValue)
+    .doesNotContainKey("999")
+    .containsValue(expectedStoreValue::equals);
+```
+
+A single chain can assert several output topics, the DLQ and the state stores, and can even feed additional records
+with `andGiven(...)`:
+
+```java
+test()
+    .given(inputTopic)
+    .record("1", inputValue)
+    .and(secondInputTopic)
+    .record("1", otherInputValue)
+    .when()
+    .then(outputTopic)
+    .containsRecord("1", expectedOutputValue)
+    .andDlq()
+    .isEmpty()
+    .andStateStore("my-store")
+    .containsKey("1");
+```
+
+For windowed and time-dependent topologies, control event time and wall clock time. As defined by Kafka Streams,
+`advanceTime(...)` only moves the event time used by the records piped afterwards, while `advanceWallClockTime(...)`
+only triggers the wall-clock-time punctuators:
+
+```java
+test()
+    .given(inputTopic)
+    .record("1", firstInputValue, Instant.parse("2026-08-17T10:00:00Z"))
+    .advanceTime(Duration.ofMinutes(5))
+    .record("2", secondInputValue)
+    .when()
+    .advanceWallClockTime(Duration.ofSeconds(10))
+    .then(outputTopic)
+    .containsKey("1");
+```
+
+A record piped without an explicit timestamp uses the current event time, which starts at `getInitialWallClockTime()`
+and moves with `advanceTime(...)` and with the last explicitly timestamped record.
+
+When an assertion fails, the DSL reports the topic, the expectation and the records actually produced:
+
+```
+Expected 2 record(s) on topic 'output_topic' but found 1.
+Actual records:
+  1=EXPECTED_OUTPUT_VALUE
+```
+
+The DSL is an additive layer: existing tests keep working and advanced scenarios can still access the underlying
+`TopologyTestDriver` through `driver()`, which is available on every stage. The same context is used for the whole test
+method, so the records read by `then(...)` and `thenDlq()` are accumulated and can be asserted several times.
 
 ## Avro Serializer and Deserializer
 

--- a/kstreamplify-core-test/src/main/java/com/michelin/kstreamplify/KafkaStreamsStarterTest.java
+++ b/kstreamplify-core-test/src/main/java/com/michelin/kstreamplify/KafkaStreamsStarterTest.java
@@ -28,6 +28,7 @@ import com.michelin.kstreamplify.context.KafkaStreamsExecutionContext;
 import com.michelin.kstreamplify.initializer.KafkaStreamsStarter;
 import com.michelin.kstreamplify.serde.SerdesUtils;
 import com.michelin.kstreamplify.serde.TopicWithSerde;
+import com.michelin.kstreamplify.test.KstreamplifyTestContext;
 import io.confluent.kafka.schemaregistry.testutil.MockSchemaRegistry;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -57,6 +58,8 @@ public abstract class KafkaStreamsStarterTest {
     /** The DLQ topic. */
     protected TestOutputTopic<String, KafkaError> dlqTopic;
 
+    private KstreamplifyTestContext testContext;
+
     /** Constructor. */
     protected KafkaStreamsStarterTest() {}
 
@@ -84,6 +87,8 @@ public abstract class KafkaStreamsStarterTest {
                 KafkaStreamsExecutionContext.getDlqTopicName(),
                 new StringDeserializer(),
                 SerdesUtils.<KafkaError>getValueSerdes().deserializer());
+
+        testContext = new KstreamplifyTestContext(testDriver, dlqTopic, getInitialWallClockTime());
     }
 
     /**
@@ -134,12 +139,24 @@ public abstract class KafkaStreamsStarterTest {
     }
 
     /**
+     * Start a fluent {@code Given → When → Then} test scenario on the topology under test. The same context is returned
+     * for the whole test method, so the event time advancement and the records already read are preserved across the
+     * calls.
+     *
+     * @return The {@link KstreamplifyTestContext} bound to the current test driver
+     */
+    protected KstreamplifyTestContext test() {
+        return testContext;
+    }
+
+    /**
      * Close everything after each test.
      *
      * @throws IOException If an I/O error occurs while deleting the state directory
      */
     @AfterEach
     protected void generalTearDown() throws IOException {
+        testContext = null;
         testDriver.close();
         Files.deleteIfExists(
                 Path.of(KafkaStreamsExecutionContext.getProperties().getProperty(STATE_DIR_CONFIG)));

--- a/kstreamplify-core-test/src/main/java/com/michelin/kstreamplify/test/AssertionStage.java
+++ b/kstreamplify-core-test/src/main/java/com/michelin/kstreamplify/test/AssertionStage.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kstreamplify.test;
+
+import com.michelin.kstreamplify.serde.TopicWithSerde;
+import org.apache.kafka.streams.TopologyTestDriver;
+
+/**
+ * Base class of all the {@code then} stages of the testing DSL. It keeps a reference to the parent
+ * {@link KstreamplifyTestContext} so that a single fluent chain can assert on several output topics, on the dead letter
+ * queue and on state stores, or feed additional records.
+ */
+public abstract class AssertionStage {
+    private final KstreamplifyTestContext context;
+
+    /**
+     * Constructor.
+     *
+     * @param context The parent test context
+     */
+    AssertionStage(KstreamplifyTestContext context) {
+        this.context = context;
+    }
+
+    /**
+     * Continue the chain with typed assertions on another output topic.
+     *
+     * @param topic The output topic to assert on
+     * @param <K> The type of the key
+     * @param <V> The type of the value
+     * @return An {@link OutputAssertion} holding the records produced on the provided topic
+     */
+    public <K, V> OutputAssertion<K, V> and(TopicWithSerde<K, V> topic) {
+        return context.then(topic);
+    }
+
+    /**
+     * Continue the chain with assertions on the records sent to the dead letter queue.
+     *
+     * @return A {@link DlqAssertion} holding the DLQ records
+     */
+    public DlqAssertion andDlq() {
+        return context.thenDlq();
+    }
+
+    /**
+     * Continue the chain with assertions on the content of the provided key-value state store.
+     *
+     * @param storeName The name of the state store
+     * @param <K> The type of the key
+     * @param <V> The type of the value
+     * @return A {@link StateStoreAssertion} bound to the state store
+     */
+    public <K, V> StateStoreAssertion<K, V> andStateStore(String storeName) {
+        return context.thenStateStore(storeName);
+    }
+
+    /**
+     * Continue the chain by feeding additional records to an input topic.
+     *
+     * @param topic The input topic to feed
+     * @param <K> The type of the key
+     * @param <V> The type of the value
+     * @return A {@link GivenStage} bound to the provided topic
+     */
+    public <K, V> GivenStage<K, V> andGiven(TopicWithSerde<K, V> topic) {
+        return context.given(topic);
+    }
+
+    /**
+     * Expose the underlying topology test driver as an escape hatch for advanced tests.
+     *
+     * @return The underlying topology test driver
+     */
+    public TopologyTestDriver driver() {
+        return context.driver();
+    }
+}

--- a/kstreamplify-core-test/src/main/java/com/michelin/kstreamplify/test/DlqAssertion.java
+++ b/kstreamplify-core-test/src/main/java/com/michelin/kstreamplify/test/DlqAssertion.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kstreamplify.test;
+
+import static com.michelin.kstreamplify.test.KstreamplifyTestContext.display;
+import static com.michelin.kstreamplify.test.KstreamplifyTestContext.format;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.michelin.kstreamplify.avro.KafkaError;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.apache.kafka.streams.test.TestRecord;
+
+/**
+ * First-class assertions on the records sent to the dead letter queue. The assertions operate on a snapshot of all the
+ * records sent to the dead letter queue since the beginning of the test.
+ */
+public final class DlqAssertion extends AssertionStage {
+    private final String topicName;
+    private final List<DlqRecord> records;
+
+    /**
+     * Constructor.
+     *
+     * @param context The parent test context
+     * @param topicName The name of the dead letter queue topic
+     * @param records The snapshot of the records sent to the dead letter queue
+     */
+    DlqAssertion(KstreamplifyTestContext context, String topicName, List<TestRecord<String, KafkaError>> records) {
+        super(context);
+        this.topicName = topicName;
+        this.records = records.stream().map(DlqRecord::new).collect(Collectors.toList());
+    }
+
+    /**
+     * Assert that the dead letter queue contains exactly the provided number of records.
+     *
+     * @param expectedCount The expected number of records
+     * @return This assertion for chaining
+     */
+    public DlqAssertion hasExactly(int expectedCount) {
+        if (records.size() != expectedCount) {
+            fail(String.format(
+                    "Expected %d record(s) on DLQ topic '%s' but found %d.%nActual DLQ records:%n%s",
+                    expectedCount, topicName, records.size(), formatRecords()));
+        }
+        return this;
+    }
+
+    /**
+     * Assert that no record reached the dead letter queue.
+     *
+     * @return This assertion for chaining
+     */
+    public DlqAssertion isEmpty() {
+        if (!records.isEmpty()) {
+            fail(String.format(
+                    "Expected no record on DLQ topic '%s' but found %d.%nActual DLQ records:%n%s",
+                    topicName, records.size(), formatRecords()));
+        }
+        return this;
+    }
+
+    /**
+     * Assert that the dead letter queue contains at least one record with the provided key.
+     *
+     * @param expectedKey The expected key
+     * @return This assertion for chaining
+     */
+    public DlqAssertion containsKey(String expectedKey) {
+        boolean found = records.stream().anyMatch(record -> Objects.equals(record.key(), expectedKey));
+        if (!found) {
+            fail(String.format(
+                    "Expected a DLQ record for key '%s'.%nActual DLQ records:%n%s",
+                    display(expectedKey), formatRecords()));
+        }
+        return this;
+    }
+
+    /**
+     * Assert that the dead letter queue contains at least one record produced by the provided exception type.
+     *
+     * @param exceptionType The expected exception type
+     * @return This assertion for chaining
+     */
+    public DlqAssertion containsError(Class<? extends Throwable> exceptionType) {
+        String expectedTypeName = exceptionType.getName();
+        boolean found = records.stream().anyMatch(record -> expectedTypeName.equals(record.exceptionTypeName()));
+        if (!found) {
+            fail(String.format(
+                    "Expected a DLQ record with exception type '%s'.%nActual DLQ records:%n%s",
+                    expectedTypeName, formatRecords()));
+        }
+        return this;
+    }
+
+    /**
+     * Assert that the dead letter queue contains at least one record produced by the provided exception type and
+     * carrying an error message containing the provided text.
+     *
+     * @param exceptionType The expected exception type
+     * @param expectedMessage The expected error message fragment
+     * @return This assertion for chaining
+     */
+    public DlqAssertion containsError(Class<? extends Throwable> exceptionType, String expectedMessage) {
+        String expectedTypeName = exceptionType.getName();
+        boolean found = records.stream()
+                .anyMatch(record -> expectedTypeName.equals(record.exceptionTypeName())
+                        && containsMessage(record, expectedMessage));
+        if (!found) {
+            fail(String.format(
+                    "Expected a DLQ record with exception type '%s' and message containing '%s'."
+                            + "%nActual DLQ records:%n%s",
+                    expectedTypeName, expectedMessage, formatRecords()));
+        }
+        return this;
+    }
+
+    /**
+     * Assert that the dead letter queue contains at least one record whose error message contains the provided text.
+     *
+     * @param expectedMessage The expected error message fragment
+     * @return This assertion for chaining
+     */
+    public DlqAssertion containsErrorMessage(String expectedMessage) {
+        boolean found = records.stream().anyMatch(record -> containsMessage(record, expectedMessage));
+        if (!found) {
+            fail(String.format(
+                    "Expected a DLQ record with an error message containing '%s'.%nActual DLQ records:%n%s",
+                    expectedMessage, formatRecords()));
+        }
+        return this;
+    }
+
+    /**
+     * Assert that the dead letter queue contains at least one record carrying the provided string header.
+     *
+     * @param key The expected header key
+     * @param value The expected header value
+     * @return This assertion for chaining
+     */
+    public DlqAssertion containsHeader(String key, String value) {
+        boolean found = records.stream().anyMatch(record -> value.equals(record.header(key)));
+        if (!found) {
+            fail(String.format(
+                    "Expected a DLQ record with header '%s'='%s'.%nActual '%s' headers:%n%s",
+                    key,
+                    value,
+                    key,
+                    format(records.stream()
+                            .map(record -> display(record.key()) + " -> " + display(record.header(key)))
+                            .collect(Collectors.toList()))));
+        }
+        return this;
+    }
+
+    /**
+     * Assert that the dead letter queue contains at least one record satisfying the provided predicate.
+     *
+     * @param predicate The predicate a record must satisfy
+     * @return This assertion for chaining
+     */
+    public DlqAssertion contains(Predicate<DlqRecord> predicate) {
+        boolean found = records.stream().anyMatch(predicate);
+        if (!found) {
+            fail(String.format(
+                    "Expected a DLQ record matching the given predicate.%nActual DLQ records:%n%s", formatRecords()));
+        }
+        return this;
+    }
+
+    /**
+     * Apply a custom assertion to the first record sent to the dead letter queue.
+     *
+     * @param assertion The assertion to apply to the first DLQ record
+     * @return This assertion for chaining
+     */
+    public DlqAssertion satisfies(Consumer<DlqRecord> assertion) {
+        return satisfies(0, assertion);
+    }
+
+    /**
+     * Apply a custom assertion to the record sent to the dead letter queue at the provided index.
+     *
+     * @param index The index of the DLQ record to assert
+     * @param assertion The assertion to apply to the DLQ record
+     * @return This assertion for chaining
+     */
+    public DlqAssertion satisfies(int index, Consumer<DlqRecord> assertion) {
+        if (index >= records.size()) {
+            fail(String.format(
+                    "Expected at least %d record(s) on DLQ topic '%s' but found %d.%nActual DLQ records:%n%s",
+                    index + 1, topicName, records.size(), formatRecords()));
+        }
+        assertion.accept(records.get(index));
+        return this;
+    }
+
+    /**
+     * Get the snapshot of the DLQ records for advanced assertions.
+     *
+     * @return The unmodifiable list of the DLQ records
+     */
+    public List<DlqRecord> records() {
+        return List.copyOf(records);
+    }
+
+    /**
+     * Check whether the error message of the provided record contains the provided text.
+     *
+     * @param record The record to inspect
+     * @param expectedMessage The expected error message fragment
+     * @return {@code true} if the error message contains the provided text, {@code false} otherwise
+     */
+    private boolean containsMessage(DlqRecord record, String expectedMessage) {
+        String errorMessage = record.errorMessage();
+        return errorMessage != null && errorMessage.contains(expectedMessage);
+    }
+
+    /**
+     * Format the DLQ records for diagnostics.
+     *
+     * @return The formatted DLQ records
+     */
+    private String formatRecords() {
+        return format(records.stream().map(DlqRecord::toString).collect(Collectors.toList()));
+    }
+}

--- a/kstreamplify-core-test/src/main/java/com/michelin/kstreamplify/test/DlqRecord.java
+++ b/kstreamplify-core-test/src/main/java/com/michelin/kstreamplify/test/DlqRecord.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kstreamplify.test;
+
+import com.michelin.kstreamplify.avro.KafkaError;
+import java.nio.charset.StandardCharsets;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.streams.test.TestRecord;
+
+/**
+ * Immutable view of a record that reached the dead letter queue. It hides the internal {@link KafkaError}
+ * representation behind a behavior-oriented API while still exposing the raw error for advanced assertions.
+ */
+public final class DlqRecord {
+    private final String key;
+    private final KafkaError error;
+    private final Headers headers;
+
+    /**
+     * Constructor.
+     *
+     * @param record The raw record read from the dead letter queue
+     */
+    DlqRecord(TestRecord<String, KafkaError> record) {
+        this.key = record.key();
+        this.error = record.value();
+        this.headers = record.headers() != null ? record.headers() : new RecordHeaders();
+    }
+
+    /**
+     * Get the key of the failed record.
+     *
+     * @return The key of the failed record
+     */
+    public String key() {
+        return key;
+    }
+
+    /**
+     * Get the raw error stored in the dead letter queue.
+     *
+     * @return The raw error
+     */
+    public KafkaError error() {
+        return error;
+    }
+
+    /**
+     * Get the headers of the record sent to the dead letter queue.
+     *
+     * @return The headers of the record
+     */
+    public Headers headers() {
+        return headers;
+    }
+
+    /**
+     * Get the value of the provided string header.
+     *
+     * @param key The header key
+     * @return The header value, or {@code null} if the header is absent
+     */
+    public String header(String key) {
+        Header header = headers.lastHeader(key);
+        if (header == null || header.value() == null) {
+            return null;
+        }
+        return new String(header.value(), StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Get the fully qualified name of the exception, parsed from the stack trace.
+     *
+     * @return The exception type name, or {@code null} if it cannot be resolved
+     */
+    public String exceptionTypeName() {
+        if (error == null || error.getStack() == null || error.getStack().isBlank()) {
+            return null;
+        }
+
+        String firstLine = error.getStack().lines().findFirst().orElse("");
+        int colonIndex = firstLine.indexOf(':');
+        String exceptionTypeName = colonIndex >= 0 ? firstLine.substring(0, colonIndex) : firstLine;
+        return exceptionTypeName.trim();
+    }
+
+    /**
+     * Get the error message of the exception that caused the failure.
+     *
+     * @return The error message, or {@code null} if none
+     */
+    public String errorMessage() {
+        if (error == null) {
+            return null;
+        }
+        return error.getCause();
+    }
+
+    /**
+     * Get the context message attached to the failure.
+     *
+     * @return The context message, or {@code null} if none
+     */
+    public String contextMessage() {
+        if (error == null) {
+            return null;
+        }
+        return error.getContextMessage();
+    }
+
+    /**
+     * Format this record for diagnostics.
+     *
+     * @return The formatted record
+     */
+    @Override
+    public String toString() {
+        return String.format(
+                "key='%s', exception=%s, message=%s",
+                KstreamplifyTestContext.display(key),
+                KstreamplifyTestContext.display(exceptionTypeName()),
+                KstreamplifyTestContext.display(errorMessage()));
+    }
+}

--- a/kstreamplify-core-test/src/main/java/com/michelin/kstreamplify/test/GivenStage.java
+++ b/kstreamplify-core-test/src/main/java/com/michelin/kstreamplify/test/GivenStage.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kstreamplify.test;
+
+import com.michelin.kstreamplify.serde.TopicWithSerde;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.TopologyTestDriver;
+
+/**
+ * Fluent stage feeding records to a single input topic. Records are piped to the underlying {@link TopologyTestDriver}
+ * as they are declared.
+ *
+ * @param <K> The type of the key
+ * @param <V> The type of the value
+ */
+public final class GivenStage<K, V> {
+    private final KstreamplifyTestContext context;
+    private final TestInputTopic<K, V> inputTopic;
+
+    /**
+     * Constructor.
+     *
+     * @param context The parent test context
+     * @param topic The input topic fed by this stage
+     */
+    GivenStage(KstreamplifyTestContext context, TopicWithSerde<K, V> topic) {
+        this.context = context;
+        this.inputTopic = context.inputTopic(topic);
+    }
+
+    /**
+     * Pipe a record using the current event time.
+     *
+     * @param key The record key
+     * @param value The record value
+     * @return This stage for chaining
+     */
+    public GivenStage<K, V> record(K key, V value) {
+        inputTopic.pipeInput(key, value, context.currentTime());
+        return this;
+    }
+
+    /**
+     * Pipe a record using the provided timestamp. The provided timestamp becomes the current event time, so the records
+     * piped afterward without an explicit timestamp use it.
+     *
+     * @param key The record key
+     * @param value The record value
+     * @param timestamp The event time of the record
+     * @return This stage for chaining
+     */
+    public GivenStage<K, V> record(K key, V value, Instant timestamp) {
+        inputTopic.pipeInput(key, value, timestamp);
+        context.currentTime(timestamp);
+        return this;
+    }
+
+    /**
+     * Pipe a bulk collection of records using the current event time.
+     *
+     * @param records The records to pipe
+     * @return This stage for chaining
+     */
+    public GivenStage<K, V> records(Collection<KeyValue<K, V>> records) {
+        records.forEach(record -> inputTopic.pipeInput(record.key, record.value, context.currentTime()));
+        return this;
+    }
+
+    /**
+     * Switch to another input topic while staying in the {@code given} stage.
+     *
+     * @param topic The next input topic to feed
+     * @param <K2> The type of the next key
+     * @param <V2> The type of the next value
+     * @return A new {@link GivenStage} bound to the provided topic
+     */
+    public <K2, V2> GivenStage<K2, V2> and(TopicWithSerde<K2, V2> topic) {
+        return context.given(topic);
+    }
+
+    /**
+     * Advance the event time used by the records piped afterward without an explicit timestamp. As defined by Kafka
+     * Streams, it does not advance the wall clock time of the topology test driver.
+     *
+     * @param duration The duration to advance the event time by
+     * @return This stage for chaining
+     */
+    public GivenStage<K, V> advanceTime(Duration duration) {
+        context.advanceTime(duration);
+        return this;
+    }
+
+    /**
+     * Advance the wall clock time of the topology test driver to trigger the wall-clock-time punctuators. As defined by
+     * Kafka Streams, it does not advance the event time used by the records piped afterward.
+     *
+     * @param duration The duration to advance the wall clock time by
+     * @return This stage for chaining
+     */
+    public GivenStage<K, V> advanceWallClockTime(Duration duration) {
+        context.advanceWallClockTime(duration);
+        return this;
+    }
+
+    /**
+     * Mark the point at which the supplied inputs have been processed by the topology.
+     *
+     * @return A {@link WhenStage} to chain assertions
+     */
+    public WhenStage when() {
+        return context.when();
+    }
+
+    /**
+     * Start typed assertions on the records produced on the provided output topic.
+     *
+     * @param topic The output topic to assert on
+     * @param <OK> The type of the output key
+     * @param <OV> The type of the output value
+     * @return An {@link OutputAssertion} holding the produced records
+     */
+    public <OK, OV> OutputAssertion<OK, OV> then(TopicWithSerde<OK, OV> topic) {
+        return context.then(topic);
+    }
+
+    /**
+     * Start assertions on the records sent to the dead letter queue.
+     *
+     * @return A {@link DlqAssertion} holding the DLQ records
+     */
+    public DlqAssertion thenDlq() {
+        return context.thenDlq();
+    }
+
+    /**
+     * Start assertions on the content of the provided key-value state store.
+     *
+     * @param storeName The name of the state store
+     * @param <SK> The type of the store key
+     * @param <SV> The type of the store value
+     * @return A {@link StateStoreAssertion} bound to the state store
+     */
+    public <SK, SV> StateStoreAssertion<SK, SV> thenStateStore(String storeName) {
+        return context.thenStateStore(storeName);
+    }
+
+    /**
+     * Expose the underlying topology test driver as an escape hatch for advanced tests.
+     *
+     * @return The underlying topology test driver
+     */
+    public TopologyTestDriver driver() {
+        return context.driver();
+    }
+}

--- a/kstreamplify-core-test/src/main/java/com/michelin/kstreamplify/test/KstreamplifyTestContext.java
+++ b/kstreamplify-core-test/src/main/java/com/michelin/kstreamplify/test/KstreamplifyTestContext.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kstreamplify.test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.michelin.kstreamplify.avro.KafkaError;
+import com.michelin.kstreamplify.context.KafkaStreamsExecutionContext;
+import com.michelin.kstreamplify.serde.TopicWithSerde;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.TestOutputTopic;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.test.TestRecord;
+
+/**
+ * Fluent entry point for the Kstreamplify testing DSL. It provides a {@code Given → When → Then} API on top of the
+ * existing {@link TopologyTestDriver} infrastructure while preserving access to the underlying driver for advanced use
+ * cases.
+ *
+ * <p>A context is bound to a single test method. The records read from an output topic or from the dead letter queue
+ * are accumulated by the context, so calling {@code then(...)} or {@code thenDlq()} several times in the same test
+ * always sees all the records produced since the beginning of the test.
+ */
+public final class KstreamplifyTestContext {
+    private final TopologyTestDriver testDriver;
+    private final TestOutputTopic<String, KafkaError> dlqTopic;
+    private final Map<String, List<TestRecord<?, ?>>> readRecords = new HashMap<>();
+    private final List<TestRecord<String, KafkaError>> readDlqRecords = new ArrayList<>();
+    private Instant currentTime;
+
+    /**
+     * Constructor.
+     *
+     * @param testDriver The underlying topology test driver
+     * @param dlqTopic The DLQ output topic created by the test infrastructure
+     * @param initialTime The initial event time used for the records piped without an explicit timestamp
+     */
+    public KstreamplifyTestContext(
+            TopologyTestDriver testDriver, TestOutputTopic<String, KafkaError> dlqTopic, Instant initialTime) {
+        this.testDriver = testDriver;
+        this.dlqTopic = dlqTopic;
+        this.currentTime = initialTime;
+    }
+
+    /**
+     * Start a {@code given} stage that feeds records to the provided input topic.
+     *
+     * @param topic The input topic to feed
+     * @param <K> The type of the key
+     * @param <V> The type of the value
+     * @return A {@link GivenStage} bound to the provided topic
+     */
+    public <K, V> GivenStage<K, V> given(TopicWithSerde<K, V> topic) {
+        return new GivenStage<>(this, topic);
+    }
+
+    /**
+     * Mark the point at which the supplied inputs have been processed by the topology.
+     *
+     * @return A {@link WhenStage} to chain output, DLQ or state store assertions
+     */
+    public WhenStage when() {
+        return new WhenStage(this);
+    }
+
+    /**
+     * Start typed assertions on the records produced on the provided output topic.
+     *
+     * @param topic The output topic to assert on
+     * @param <K> The type of the key
+     * @param <V> The type of the value
+     * @return An {@link OutputAssertion} holding the produced records
+     */
+    public <K, V> OutputAssertion<K, V> then(TopicWithSerde<K, V> topic) {
+        return new OutputAssertion<>(this, topic.toString(), readOutputRecords(topic));
+    }
+
+    /**
+     * Start assertions on the records sent to the dead letter queue.
+     *
+     * @return A {@link DlqAssertion} holding the DLQ records
+     */
+    public DlqAssertion thenDlq() {
+        readDlqRecords.addAll(dlqTopic.readRecordsToList());
+        return new DlqAssertion(this, KafkaStreamsExecutionContext.getDlqTopicName(), List.copyOf(readDlqRecords));
+    }
+
+    /**
+     * Start assertions on the content of the provided key-value state store.
+     *
+     * @param storeName The name of the state store
+     * @param <K> The type of the key
+     * @param <V> The type of the value
+     * @return A {@link StateStoreAssertion} bound to the state store
+     */
+    public <K, V> StateStoreAssertion<K, V> thenStateStore(String storeName) {
+        KeyValueStore<K, V> store = testDriver.getKeyValueStore(storeName);
+        if (store == null) {
+            fail(String.format(
+                    "No key-value state store named '%s' in the topology.%nAvailable state stores:%n%s",
+                    storeName, formatStateStoreNames()));
+        }
+        return new StateStoreAssertion<>(this, storeName, store);
+    }
+
+    /**
+     * Advance the event time used by the records piped afterward without an explicit timestamp. As defined by Kafka
+     * Streams, it does not advance the wall clock time of the topology test driver.
+     *
+     * @param duration The duration to advance the event time by
+     * @return This context for chaining
+     */
+    public KstreamplifyTestContext advanceTime(Duration duration) {
+        this.currentTime = this.currentTime.plus(duration);
+        return this;
+    }
+
+    /**
+     * Advance the wall clock time of the topology test driver to trigger the wall-clock-time punctuators. As defined by
+     * Kafka Streams, it does not advance the event time used by the records piped afterward.
+     *
+     * @param duration The duration to advance the wall clock time by
+     * @return This context for chaining
+     */
+    public KstreamplifyTestContext advanceWallClockTime(Duration duration) {
+        testDriver.advanceWallClockTime(duration);
+        return this;
+    }
+
+    /**
+     * Expose the underlying topology test driver as an escape hatch for advanced tests.
+     *
+     * @return The underlying topology test driver
+     */
+    public TopologyTestDriver driver() {
+        return testDriver;
+    }
+
+    /**
+     * Get the event time used by the records piped without an explicit timestamp.
+     *
+     * @return The current event time
+     */
+    Instant currentTime() {
+        return currentTime;
+    }
+
+    /**
+     * Set the event time used by the records piped without an explicit timestamp.
+     *
+     * @param instant The new current event time
+     */
+    void currentTime(Instant instant) {
+        this.currentTime = instant;
+    }
+
+    /**
+     * Create the test input topic backing the provided topic.
+     *
+     * @param topic The topic to resolve
+     * @param <K> The type of the key
+     * @param <V> The type of the value
+     * @return The newly created test input topic
+     */
+    <K, V> TestInputTopic<K, V> inputTopic(TopicWithSerde<K, V> topic) {
+        return testDriver.createInputTopic(
+                topic.toString(),
+                topic.getKeySerde().serializer(),
+                topic.getValueSerde().serializer());
+    }
+
+    /**
+     * Read the records produced on the provided topic since the last read and return all the records produced since the
+     * beginning of the test.
+     *
+     * @param topic The topic to read
+     * @param <K> The type of the key
+     * @param <V> The type of the value
+     * @return All the records produced on the topic since the beginning of the test
+     */
+    @SuppressWarnings("unchecked")
+    private <K, V> List<TestRecord<K, V>> readOutputRecords(TopicWithSerde<K, V> topic) {
+        TestOutputTopic<K, V> outputTopic = testDriver.createOutputTopic(
+                topic.toString(),
+                topic.getKeySerde().deserializer(),
+                topic.getValueSerde().deserializer());
+
+        List<TestRecord<?, ?>> records = readRecords.computeIfAbsent(topic.toString(), name -> new ArrayList<>());
+        records.addAll(outputTopic.readRecordsToList());
+
+        return List.copyOf((List<TestRecord<K, V>>) (List<?>) records);
+    }
+
+    /**
+     * Format the names of the state stores of the topology for diagnostics.
+     *
+     * @return The formatted state store names
+     */
+    private String formatStateStoreNames() {
+        Map<String, ?> stateStores = testDriver.getAllStateStores();
+        if (stateStores.isEmpty()) {
+            return "  <none>";
+        }
+        return format(new ArrayList<>(new TreeSet<>(stateStores.keySet())));
+    }
+
+    /**
+     * Format a list of elements, one indented element per line, for diagnostics.
+     *
+     * @param elements The elements to format
+     * @return The formatted elements
+     */
+    static String format(List<String> elements) {
+        if (elements.isEmpty()) {
+            return "  <none>";
+        }
+        return elements.stream().map(element -> "  " + element).collect(Collectors.joining(System.lineSeparator()));
+    }
+
+    /**
+     * Format a possibly null object for diagnostics.
+     *
+     * @param value The value to format
+     * @return The formatted value
+     */
+    static String display(Object value) {
+        if (value == null) {
+            return "<null>";
+        }
+        return value.toString();
+    }
+}

--- a/kstreamplify-core-test/src/main/java/com/michelin/kstreamplify/test/OutputAssertion.java
+++ b/kstreamplify-core-test/src/main/java/com/michelin/kstreamplify/test/OutputAssertion.java
@@ -1,0 +1,336 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kstreamplify.test;
+
+import static com.michelin.kstreamplify.test.KstreamplifyTestContext.display;
+import static com.michelin.kstreamplify.test.KstreamplifyTestContext.format;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.streams.test.TestRecord;
+
+/**
+ * Typed assertions on the records produced on an output topic. The assertions operate on a snapshot of all the records
+ * produced on the topic since the beginning of the test.
+ *
+ * @param <K> The type of the key
+ * @param <V> The type of the value
+ */
+public final class OutputAssertion<K, V> extends AssertionStage {
+    private final String topicName;
+    private final List<TestRecord<K, V>> records;
+
+    /**
+     * Constructor.
+     *
+     * @param context The parent test context
+     * @param topicName The name of the output topic
+     * @param records The snapshot of the records produced on the topic
+     */
+    OutputAssertion(KstreamplifyTestContext context, String topicName, List<TestRecord<K, V>> records) {
+        super(context);
+        this.topicName = topicName;
+        this.records = records;
+    }
+
+    /**
+     * Assert that the topic contains exactly the provided number of records.
+     *
+     * @param expectedCount The expected number of records
+     * @return This assertion for chaining
+     */
+    public OutputAssertion<K, V> hasExactly(int expectedCount) {
+        if (records.size() != expectedCount) {
+            fail(String.format(
+                    "Expected %d record(s) on topic '%s' but found %d.%nActual records:%n%s",
+                    expectedCount, topicName, records.size(), formatRecords()));
+        }
+        return this;
+    }
+
+    /**
+     * Assert that the topic did not produce any record.
+     *
+     * @return This assertion for chaining
+     */
+    public OutputAssertion<K, V> isEmpty() {
+        if (!records.isEmpty()) {
+            fail(String.format(
+                    "Expected no record on topic '%s' but found %d.%nActual records:%n%s",
+                    topicName, records.size(), formatRecords()));
+        }
+        return this;
+    }
+
+    /**
+     * Assert that the topic produced at least one record with the provided key.
+     *
+     * @param key The expected key
+     * @return This assertion for chaining
+     */
+    public OutputAssertion<K, V> containsKey(K key) {
+        boolean found = records.stream().anyMatch(record -> Objects.equals(record.key(), key));
+        if (!found) {
+            fail(String.format(
+                    "Expected a record with key '%s' on topic '%s'.%nActual keys:%n%s",
+                    display(key), topicName, format(keys())));
+        }
+        return this;
+    }
+
+    /**
+     * Assert that the topic did not produce any record with the provided key.
+     *
+     * @param key The key that must be absent
+     * @return This assertion for chaining
+     */
+    public OutputAssertion<K, V> doesNotContainKey(K key) {
+        boolean found = records.stream().anyMatch(record -> Objects.equals(record.key(), key));
+        if (found) {
+            fail(String.format(
+                    "Expected no record with key '%s' on topic '%s'.%nActual records:%n%s",
+                    display(key), topicName, formatRecords()));
+        }
+        return this;
+    }
+
+    /**
+     * Assert that the topic produced at least one record matching the provided key and value.
+     *
+     * @param key The expected key
+     * @param value The expected value
+     * @return This assertion for chaining
+     */
+    public OutputAssertion<K, V> containsRecord(K key, V value) {
+        boolean found = records.stream()
+                .anyMatch(record -> Objects.equals(record.key(), key) && Objects.equals(record.value(), value));
+        if (!found) {
+            fail(String.format(
+                    "Expected a record with key '%s' and value '%s' on topic '%s'.%nActual records:%n%s",
+                    display(key), display(value), topicName, formatRecords()));
+        }
+        return this;
+    }
+
+    /**
+     * Assert that the topic produced at least one record whose value satisfies the provided predicate.
+     *
+     * @param predicate The predicate the value must satisfy
+     * @return This assertion for chaining
+     */
+    public OutputAssertion<K, V> containsValue(Predicate<V> predicate) {
+        boolean found = records.stream().map(TestRecord::value).anyMatch(predicate);
+        if (!found) {
+            fail(String.format(
+                    "Expected a record matching the given value predicate on topic '%s'.%nActual records:%n%s",
+                    topicName, formatRecords()));
+        }
+        return this;
+    }
+
+    /**
+     * Assert that the topic produced at least one record carrying the provided string header.
+     *
+     * @param key The expected header key
+     * @param value The expected header value
+     * @return This assertion for chaining
+     */
+    public OutputAssertion<K, V> containsHeader(String key, String value) {
+        boolean found = records.stream().anyMatch(record -> value.equals(header(record, key)));
+        if (!found) {
+            fail(String.format(
+                    "Expected a record with header '%s'='%s' on topic '%s'.%nActual '%s' headers:%n%s",
+                    key, value, topicName, key, format(headers(key))));
+        }
+        return this;
+    }
+
+    /**
+     * Assert that the records produced on the topic match exactly the provided key-value entries, in order.
+     *
+     * @param entries The expected key-value entries
+     * @return This assertion for chaining
+     */
+    @SafeVarargs
+    public final OutputAssertion<K, V> containsExactly(Map.Entry<K, V>... entries) {
+        List<Map.Entry<K, V>> expectedEntries = List.of(entries);
+        if (records.size() != expectedEntries.size()) {
+            fail(String.format(
+                    "Expected %d record(s) on topic '%s' but found %d.%nMissing keys:%n%s%nUnexpected keys:%n%s"
+                            + "%nActual records:%n%s",
+                    expectedEntries.size(),
+                    topicName,
+                    records.size(),
+                    format(missingKeys(expectedEntries)),
+                    format(unexpectedKeys(expectedEntries)),
+                    formatRecords()));
+        }
+
+        for (int index = 0; index < expectedEntries.size(); index++) {
+            TestRecord<K, V> actual = records.get(index);
+            Map.Entry<K, V> expected = expectedEntries.get(index);
+            if (!Objects.equals(actual.key(), expected.getKey())
+                    || !Objects.equals(actual.value(), expected.getValue())) {
+                fail(String.format(
+                        "Record at index %d on topic '%s' does not match.%nExpected: %s=%s%nActual:   %s=%s",
+                        index,
+                        topicName,
+                        display(expected.getKey()),
+                        display(expected.getValue()),
+                        display(actual.key()),
+                        display(actual.value())));
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Apply a custom assertion to the first record produced on the topic.
+     *
+     * @param assertion The assertion to apply to the first record
+     * @return This assertion for chaining
+     */
+    public OutputAssertion<K, V> satisfies(Consumer<TestRecord<K, V>> assertion) {
+        return satisfies(0, assertion);
+    }
+
+    /**
+     * Apply a custom assertion to the record produced at the provided index.
+     *
+     * @param index The index of the record to assert
+     * @param assertion The assertion to apply to the record
+     * @return This assertion for chaining
+     */
+    public OutputAssertion<K, V> satisfies(int index, Consumer<TestRecord<K, V>> assertion) {
+        if (index >= records.size()) {
+            fail(String.format(
+                    "Expected at least %d record(s) on topic '%s' but found %d.%nActual records:%n%s",
+                    index + 1, topicName, records.size(), formatRecords()));
+        }
+        assertion.accept(records.get(index));
+        return this;
+    }
+
+    /**
+     * Apply a custom assertion to every record produced on the topic. It fails when the topic did not produce any
+     * record.
+     *
+     * @param assertion The assertion to apply to each record
+     * @return This assertion for chaining
+     */
+    public OutputAssertion<K, V> allSatisfy(Consumer<TestRecord<K, V>> assertion) {
+        if (records.isEmpty()) {
+            fail(String.format("Expected at least one record on topic '%s' but found none.", topicName));
+        }
+        records.forEach(assertion);
+        return this;
+    }
+
+    /**
+     * Get the snapshot of the records produced on the topic for advanced assertions.
+     *
+     * @return The unmodifiable list of the produced records
+     */
+    public List<TestRecord<K, V>> records() {
+        return records;
+    }
+
+    /**
+     * Get the value of the provided header of a record.
+     *
+     * @param record The record to inspect
+     * @param key The header key
+     * @return The header value, or {@code null} if the header is absent
+     */
+    private String header(TestRecord<K, V> record, String key) {
+        Header header = record.headers().lastHeader(key);
+        if (header == null || header.value() == null) {
+            return null;
+        }
+        return new String(header.value(), StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Get the keys of the records produced on the topic.
+     *
+     * @return The formatted keys
+     */
+    private List<String> keys() {
+        return records.stream().map(record -> display(record.key())).collect(Collectors.toList());
+    }
+
+    /**
+     * Get the values of the provided header for all the records produced on the topic.
+     *
+     * @param key The header key
+     * @return The formatted header values
+     */
+    private List<String> headers(String key) {
+        return records.stream()
+                .map(record -> display(record.key()) + " -> " + display(header(record, key)))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Get the expected keys that were not produced on the topic.
+     *
+     * @param expectedEntries The expected key-value entries
+     * @return The formatted missing keys
+     */
+    private List<String> missingKeys(List<Map.Entry<K, V>> expectedEntries) {
+        List<String> actualKeys = keys();
+        List<String> missingKeys = new ArrayList<>();
+        expectedEntries.stream()
+                .map(entry -> display(entry.getKey()))
+                .filter(key -> !actualKeys.contains(key))
+                .forEach(missingKeys::add);
+        return missingKeys;
+    }
+
+    /**
+     * Get the keys produced on the topic that were not expected.
+     *
+     * @param expectedEntries The expected key-value entries
+     * @return The formatted unexpected keys
+     */
+    private List<String> unexpectedKeys(List<Map.Entry<K, V>> expectedEntries) {
+        List<String> expectedKeys =
+                expectedEntries.stream().map(entry -> display(entry.getKey())).toList();
+        return keys().stream().filter(key -> !expectedKeys.contains(key)).toList();
+    }
+
+    /**
+     * Format the records produced on the topic for diagnostics.
+     *
+     * @return The formatted records
+     */
+    private String formatRecords() {
+        return format(records.stream()
+                .map(record -> display(record.key()) + "=" + display(record.value()))
+                .collect(Collectors.toList()));
+    }
+}

--- a/kstreamplify-core-test/src/main/java/com/michelin/kstreamplify/test/StateStoreAssertion.java
+++ b/kstreamplify-core-test/src/main/java/com/michelin/kstreamplify/test/StateStoreAssertion.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kstreamplify.test;
+
+import static com.michelin.kstreamplify.test.KstreamplifyTestContext.display;
+import static com.michelin.kstreamplify.test.KstreamplifyTestContext.format;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.KeyValueStore;
+
+/**
+ * Assertions on the content of a key-value state store. The assertions read the store through the underlying
+ * {@link KeyValueStore} exposed by the topology test driver.
+ *
+ * @param <K> The type of the key
+ * @param <V> The type of the value
+ */
+public final class StateStoreAssertion<K, V> extends AssertionStage {
+    private final String storeName;
+    private final KeyValueStore<K, V> store;
+
+    /**
+     * Constructor.
+     *
+     * @param context The parent test context
+     * @param storeName The name of the state store
+     * @param store The underlying key-value store
+     */
+    StateStoreAssertion(KstreamplifyTestContext context, String storeName, KeyValueStore<K, V> store) {
+        super(context);
+        this.storeName = storeName;
+        this.store = store;
+    }
+
+    /**
+     * Assert that the state store contains the provided key.
+     *
+     * @param key The expected key
+     * @return This assertion for chaining
+     */
+    public StateStoreAssertion<K, V> containsKey(K key) {
+        if (store.get(key) == null) {
+            fail(String.format(
+                    "Expected state store '%s' to contain key '%s'.%nActual entries:%n%s",
+                    storeName, display(key), formatEntries()));
+        }
+        return this;
+    }
+
+    /**
+     * Assert that the state store does not contain the provided key.
+     *
+     * @param key The key that must be absent
+     * @return This assertion for chaining
+     */
+    public StateStoreAssertion<K, V> doesNotContainKey(K key) {
+        V value = store.get(key);
+        if (value != null) {
+            fail(String.format(
+                    "Expected state store '%s' not to contain key '%s' but it is mapped to '%s'.",
+                    storeName, display(key), display(value)));
+        }
+        return this;
+    }
+
+    /**
+     * Assert that the state store maps the provided key to the provided value.
+     *
+     * @param key The expected key
+     * @param expectedValue The expected value
+     * @return This assertion for chaining
+     */
+    public StateStoreAssertion<K, V> contains(K key, V expectedValue) {
+        V actualValue = store.get(key);
+        if (!Objects.equals(actualValue, expectedValue)) {
+            fail(String.format(
+                    "Expected state store '%s' to map key '%s' to '%s' but found '%s'.%nActual entries:%n%s",
+                    storeName, display(key), display(expectedValue), display(actualValue), formatEntries()));
+        }
+        return this;
+    }
+
+    /**
+     * Assert that the state store contains exactly the provided number of entries.
+     *
+     * @param expectedCount The expected number of entries
+     * @return This assertion for chaining
+     */
+    public StateStoreAssertion<K, V> hasExactly(int expectedCount) {
+        List<KeyValue<K, V>> entries = entries();
+        if (entries.size() != expectedCount) {
+            fail(String.format(
+                    "Expected state store '%s' to contain %d entries but found %d.%nActual entries:%n%s",
+                    storeName, expectedCount, entries.size(), formatEntries()));
+        }
+        return this;
+    }
+
+    /**
+     * Assert that the state store is empty.
+     *
+     * @return This assertion for chaining
+     */
+    public StateStoreAssertion<K, V> isEmpty() {
+        List<KeyValue<K, V>> entries = entries();
+        if (!entries.isEmpty()) {
+            fail(String.format(
+                    "Expected state store '%s' to be empty but found %d entries.%nActual entries:%n%s",
+                    storeName, entries.size(), formatEntries()));
+        }
+        return this;
+    }
+
+    /**
+     * Assert that the state store contains at least one value satisfying the provided predicate.
+     *
+     * @param predicate The predicate a value must satisfy
+     * @return This assertion for chaining
+     */
+    public StateStoreAssertion<K, V> containsValue(Predicate<V> predicate) {
+        boolean found = entries().stream().map(entry -> entry.value).anyMatch(predicate);
+        if (!found) {
+            fail(String.format(
+                    "Expected state store '%s' to contain a value matching the given predicate.%nActual entries:%n%s",
+                    storeName, formatEntries()));
+        }
+        return this;
+    }
+
+    /**
+     * Get the underlying key-value store for advanced assertions.
+     *
+     * @return The underlying key-value store
+     */
+    public KeyValueStore<K, V> store() {
+        return store;
+    }
+
+    /**
+     * Get all the entries of the state store.
+     *
+     * @return The entries of the state store
+     */
+    private List<KeyValue<K, V>> entries() {
+        List<KeyValue<K, V>> entries = new ArrayList<>();
+        try (KeyValueIterator<K, V> iterator = store.all()) {
+            while (iterator.hasNext()) {
+                entries.add(iterator.next());
+            }
+        }
+        return entries;
+    }
+
+    /**
+     * Format the entries of the state store for diagnostics.
+     *
+     * @return The formatted entries
+     */
+    private String formatEntries() {
+        return format(entries().stream()
+                .map(entry -> display(entry.key) + "=" + display(entry.value))
+                .collect(Collectors.toList()));
+    }
+}

--- a/kstreamplify-core-test/src/main/java/com/michelin/kstreamplify/test/WhenStage.java
+++ b/kstreamplify-core-test/src/main/java/com/michelin/kstreamplify/test/WhenStage.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kstreamplify.test;
+
+import com.michelin.kstreamplify.serde.TopicWithSerde;
+import java.time.Duration;
+import org.apache.kafka.streams.TopologyTestDriver;
+
+/**
+ * Fluent stage representing the point at which the supplied inputs have been processed by the topology. It is the entry
+ * point for output, DLQ and state store assertions.
+ */
+public final class WhenStage {
+    private final KstreamplifyTestContext context;
+
+    /**
+     * Constructor.
+     *
+     * @param context The parent test context
+     */
+    WhenStage(KstreamplifyTestContext context) {
+        this.context = context;
+    }
+
+    /**
+     * Start typed assertions on the records produced on the provided output topic.
+     *
+     * @param topic The output topic to assert on
+     * @param <K> The type of the key
+     * @param <V> The type of the value
+     * @return An {@link OutputAssertion} holding the produced records
+     */
+    public <K, V> OutputAssertion<K, V> then(TopicWithSerde<K, V> topic) {
+        return context.then(topic);
+    }
+
+    /**
+     * Start assertions on the records sent to the dead letter queue.
+     *
+     * @return A {@link DlqAssertion} holding the DLQ records
+     */
+    public DlqAssertion thenDlq() {
+        return context.thenDlq();
+    }
+
+    /**
+     * Start assertions on the content of the provided key-value state store.
+     *
+     * @param storeName The name of the state store
+     * @param <K> The type of the key
+     * @param <V> The type of the value
+     * @return A {@link StateStoreAssertion} bound to the state store
+     */
+    public <K, V> StateStoreAssertion<K, V> thenStateStore(String storeName) {
+        return context.thenStateStore(storeName);
+    }
+
+    /**
+     * Advance the event time used by the records piped afterward without an explicit timestamp. As defined by Kafka
+     * Streams, it does not advance the wall clock time of the topology test driver.
+     *
+     * @param duration The duration to advance the event time by
+     * @return This stage for chaining
+     */
+    public WhenStage advanceTime(Duration duration) {
+        context.advanceTime(duration);
+        return this;
+    }
+
+    /**
+     * Advance the wall clock time of the topology test driver to trigger the wall-clock-time punctuators. As defined by
+     * Kafka Streams, it does not advance the event time used by the records piped afterward.
+     *
+     * @param duration The duration to advance the wall clock time by
+     * @return This stage for chaining
+     */
+    public WhenStage advanceWallClockTime(Duration duration) {
+        context.advanceWallClockTime(duration);
+        return this;
+    }
+
+    /**
+     * Expose the underlying topology test driver as an escape hatch for advanced tests.
+     *
+     * @return The underlying topology test driver
+     */
+    public TopologyTestDriver driver() {
+        return context.driver();
+    }
+}

--- a/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/test/AbstractDslTest.java
+++ b/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/test/AbstractDslTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kstreamplify.test;
+
+import com.michelin.kstreamplify.KafkaStreamsStarterTest;
+import com.michelin.kstreamplify.error.ProcessingResult;
+import com.michelin.kstreamplify.error.TopologyErrorHandler;
+import com.michelin.kstreamplify.initializer.KafkaStreamsStarter;
+import com.michelin.kstreamplify.serde.TopicWithSerde;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.Joined;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.processor.PunctuationType;
+import org.apache.kafka.streams.processor.api.ContextualProcessor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
+import org.apache.kafka.streams.processor.api.Record;
+
+/**
+ * Base class of the testing DSL tests. It provides a topology covering the scenarios exercised by the DSL: multiple
+ * input topics, error handling to the DLQ, record headers, a stream-table join, a state store and a wall-clock-time
+ * punctuator.
+ */
+abstract class AbstractDslTest extends KafkaStreamsStarterTest {
+    protected static final String DLQ_TOPIC = "DLQ_TOPIC";
+    protected static final String USER_STORE = "user-store";
+    protected static final String CORRELATION_ID = "correlation-id";
+    protected static final String INVALID_VALUE = "boom";
+    protected static final Instant INITIAL_TIME = Instant.parse("2020-01-01T00:00:00Z");
+
+    protected static final TopicWithSerde<String, String> INPUT =
+            new TopicWithSerde<>("INPUT", Serdes.String(), Serdes.String());
+    protected static final TopicWithSerde<String, String> INPUT_2 =
+            new TopicWithSerde<>("INPUT_2", Serdes.String(), Serdes.String());
+    protected static final TopicWithSerde<String, String> OUTPUT =
+            new TopicWithSerde<>("OUTPUT", Serdes.String(), Serdes.String());
+    protected static final TopicWithSerde<String, String> USER_TOPIC =
+            new TopicWithSerde<>("USER_TOPIC", Serdes.String(), Serdes.String());
+    protected static final TopicWithSerde<String, String> ORDER_TOPIC =
+            new TopicWithSerde<>("ORDER_TOPIC", Serdes.String(), Serdes.String());
+    protected static final TopicWithSerde<String, String> JOIN_OUTPUT =
+            new TopicWithSerde<>("JOIN_OUTPUT", Serdes.String(), Serdes.String());
+    protected static final TopicWithSerde<String, String> TICK_TOPIC =
+            new TopicWithSerde<>("TICK_TOPIC", Serdes.String(), Serdes.String());
+    protected static final TopicWithSerde<String, String> TICK_OUTPUT =
+            new TopicWithSerde<>("TICK_OUTPUT", Serdes.String(), Serdes.String());
+
+    @Override
+    protected Instant getInitialWallClockTime() {
+        return INITIAL_TIME;
+    }
+
+    @Override
+    protected KafkaStreamsStarter getKafkaStreamsStarter() {
+        return new KafkaStreamsStarter() {
+            @Override
+            public String dlqTopic() {
+                return DLQ_TOPIC;
+            }
+
+            @Override
+            public void topology(StreamsBuilder streamsBuilder) {
+                buildUpperCaseTopology(streamsBuilder);
+                buildJoinTopology(streamsBuilder);
+                buildPunctuationTopology(streamsBuilder);
+            }
+        };
+    }
+
+    private void buildUpperCaseTopology(StreamsBuilder streamsBuilder) {
+        KStream<String, String> merged = INPUT.stream(streamsBuilder).merge(INPUT_2.stream(streamsBuilder));
+
+        KStream<String, ProcessingResult<String, String>> processed = merged.process(headerAdder())
+                .mapValues(value -> {
+                    if (INVALID_VALUE.equals(value)) {
+                        return ProcessingResult.fail(new IllegalStateException("Invalid value"), value);
+                    }
+                    return ProcessingResult.success(value.toUpperCase());
+                });
+
+        OUTPUT.produce(TopologyErrorHandler.catchErrors(processed));
+    }
+
+    private void buildJoinTopology(StreamsBuilder streamsBuilder) {
+        KTable<String, String> users = USER_TOPIC.table(streamsBuilder, USER_STORE);
+
+        JOIN_OUTPUT.produce(ORDER_TOPIC.stream(streamsBuilder)
+                .join(
+                        users,
+                        (order, user) -> order + "-" + user,
+                        Joined.with(Serdes.String(), Serdes.String(), Serdes.String())));
+    }
+
+    private void buildPunctuationTopology(StreamsBuilder streamsBuilder) {
+        TICK_OUTPUT.produce(TICK_TOPIC.stream(streamsBuilder).process(tickProcessor()));
+    }
+
+    private static ProcessorSupplier<String, String, String, String> headerAdder() {
+        return () -> new ContextualProcessor<>() {
+            @Override
+            public void process(Record<String, String> record) {
+                context()
+                        .forward(record.withHeaders(record.headers()
+                                .add(CORRELATION_ID, record.key().getBytes(StandardCharsets.UTF_8))));
+            }
+        };
+    }
+
+    private static ProcessorSupplier<String, String, String, String> tickProcessor() {
+        return () -> new ContextualProcessor<>() {
+            @Override
+            public void init(ProcessorContext<String, String> context) {
+                super.init(context);
+                context.schedule(
+                        Duration.ofMinutes(1),
+                        PunctuationType.WALL_CLOCK_TIME,
+                        timestamp -> context.forward(new Record<>("tick", "tick", timestamp)));
+            }
+
+            @Override
+            public void process(Record<String, String> record) {
+                context().forward(record);
+            }
+        };
+    }
+}

--- a/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/test/AssertionStageTest.java
+++ b/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/test/AssertionStageTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kstreamplify.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class AssertionStageTest extends AbstractDslTest {
+    @Test
+    void shouldChainAssertionsOnSeveralOutputTopics() {
+        test().given(INPUT)
+                .record("1", "a")
+                .and(USER_TOPIC)
+                .record("1", "Anna")
+                .and(ORDER_TOPIC)
+                .record("1", "ORDER-1")
+                .when()
+                .then(OUTPUT)
+                .containsRecord("1", "A")
+                .and(JOIN_OUTPUT)
+                .containsRecord("1", "ORDER-1-Anna");
+    }
+
+    @Test
+    void shouldChainOutputDlqAndStateStoreAssertions() {
+        test().given(INPUT)
+                .record("1", "a")
+                .record("2", INVALID_VALUE)
+                .and(USER_TOPIC)
+                .record("1", "Anna")
+                .when()
+                .then(OUTPUT)
+                .hasExactly(1)
+                .andDlq()
+                .hasExactly(1)
+                .containsKey("2")
+                .andStateStore(USER_STORE)
+                .containsKey("1");
+    }
+
+    @Test
+    void shouldFeedMoreRecordsAfterAnAssertion() {
+        test().given(INPUT)
+                .record("1", "a")
+                .when()
+                .then(OUTPUT)
+                .hasExactly(1)
+                .andGiven(INPUT)
+                .record("2", "b")
+                .when()
+                .then(OUTPUT)
+                .hasExactly(2);
+    }
+
+    @Test
+    void shouldAdvanceTimeFromTheWhenStage() {
+        test().given(INPUT)
+                .record("1", "a")
+                .when()
+                .advanceTime(Duration.ofMinutes(5))
+                .advanceWallClockTime(Duration.ofSeconds(10))
+                .then(OUTPUT)
+                .andGiven(INPUT)
+                .record("2", "b")
+                .when()
+                .then(OUTPUT)
+                .satisfies(1, record -> assertEquals(INITIAL_TIME.plus(Duration.ofMinutes(5)), record.getRecordTime()));
+    }
+}

--- a/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/test/DlqAssertionTest.java
+++ b/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/test/DlqAssertionTest.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kstreamplify.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
+
+class DlqAssertionTest extends AbstractDslTest {
+    @Test
+    void shouldAssertDlqRecord() {
+        test().given(INPUT)
+                .record("123", INVALID_VALUE)
+                .when()
+                .thenDlq()
+                .hasExactly(1)
+                .containsKey("123")
+                .containsError(IllegalStateException.class)
+                .containsError(IllegalStateException.class, "Invalid value")
+                .satisfies(record -> {
+                    assertEquals("123", record.key());
+                    assertEquals("java.lang.IllegalStateException", record.exceptionTypeName());
+                    assertEquals("Invalid value", record.errorMessage());
+                    assertEquals(INVALID_VALUE, record.error().getValue());
+                    assertNotNull(record.contextMessage());
+                    assertNotNull(record.headers());
+                    assertNull(record.header("unknown-header"));
+                })
+                .containsHeader(CORRELATION_ID, "123")
+                .contains(record -> "123".equals(record.key()))
+                .containsErrorMessage("Invalid value")
+                .hasExactly(1);
+    }
+
+    @Test
+    void shouldAssertEmptyDlqWhenNoError() {
+        test().given(INPUT).record("123", "hello").when().thenDlq().isEmpty();
+    }
+
+    @Test
+    void shouldReturnUnmodifiableDlqRecords() {
+        List<DlqRecord> records = test().given(INPUT)
+                .record("123", INVALID_VALUE)
+                .when()
+                .thenDlq()
+                .records();
+
+        assertEquals(1, records.size());
+        assertEquals("123", records.get(0).key());
+        assertThrows(UnsupportedOperationException.class, () -> records.add(null));
+    }
+
+    @Test
+    void shouldFailWhenDlqRecordCountDoesNotMatch() {
+        AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> test().given(INPUT)
+                .record("123", INVALID_VALUE)
+                .when()
+                .thenDlq()
+                .hasExactly(2));
+
+        assertTrue(error.getMessage().contains("Expected 2 record(s) on DLQ topic 'DLQ_TOPIC' but found 1"));
+        assertTrue(error.getMessage().contains("key='123'"));
+        assertTrue(error.getMessage().contains("java.lang.IllegalStateException"));
+        assertTrue(error.getMessage().contains("Invalid value"));
+    }
+
+    @Test
+    void shouldFailWhenDlqIsNotEmpty() {
+        AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> test().given(INPUT)
+                .record("123", INVALID_VALUE)
+                .when()
+                .thenDlq()
+                .isEmpty());
+
+        assertTrue(error.getMessage().contains("Expected no record on DLQ topic 'DLQ_TOPIC' but found 1"));
+    }
+
+    @Test
+    void shouldFailWhenDlqKeyIsMissing() {
+        AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> test().given(INPUT)
+                .record("123", INVALID_VALUE)
+                .when()
+                .thenDlq()
+                .containsKey("456"));
+
+        assertTrue(error.getMessage().contains("Expected a DLQ record for key '456'"));
+        assertTrue(error.getMessage().contains("key='123'"));
+    }
+
+    @Test
+    void shouldFailWithExpectedAndActualExceptionWhenErrorTypeDoesNotMatch() {
+        AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> test().given(INPUT)
+                .record("123", INVALID_VALUE)
+                .when()
+                .thenDlq()
+                .containsError(IllegalArgumentException.class));
+
+        assertTrue(error.getMessage()
+                .contains("Expected a DLQ record with exception type 'java.lang" + ".IllegalArgumentException'"));
+        assertTrue(error.getMessage().contains("exception=java.lang.IllegalStateException"));
+        assertTrue(error.getMessage().contains("message=Invalid value"));
+    }
+
+    @Test
+    void shouldFailWhenErrorTypeAndMessageDoNotMatch() {
+        AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> test().given(INPUT)
+                .record("123", INVALID_VALUE)
+                .when()
+                .thenDlq()
+                .containsError(IllegalStateException.class, "Missing customer data"));
+
+        assertTrue(error.getMessage().contains("and message containing 'Missing customer data'"));
+        assertTrue(error.getMessage().contains("message=Invalid value"));
+    }
+
+    @Test
+    void shouldFailWhenErrorMessageDoesNotMatch() {
+        AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> test().given(INPUT)
+                .record("123", INVALID_VALUE)
+                .when()
+                .thenDlq()
+                .containsErrorMessage("Missing customer data"));
+
+        assertTrue(error.getMessage()
+                .contains("Expected a DLQ record with an error message containing " + "'Missing customer data'"));
+        assertTrue(error.getMessage().contains("message=Invalid value"));
+    }
+
+    @Test
+    void shouldFailWhenDlqHeaderIsMissing() {
+        AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> test().given(INPUT)
+                .record("123", INVALID_VALUE)
+                .when()
+                .thenDlq()
+                .containsHeader(CORRELATION_ID, "456"));
+
+        assertTrue(error.getMessage().contains("Expected a DLQ record with header 'correlation-id'='456'"));
+    }
+
+    @Test
+    void shouldFailWhenNoDlqRecordMatchesPredicate() {
+        AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> test().given(INPUT)
+                .record("123", INVALID_VALUE)
+                .when()
+                .thenDlq()
+                .contains(record -> "456".equals(record.key())));
+
+        assertTrue(error.getMessage().contains("Expected a DLQ record matching the given predicate"));
+    }
+
+    @Test
+    void shouldFailWhenAssertedDlqRecordIndexDoesNotExist() {
+        AssertionFailedError error = assertThrows(
+                AssertionFailedError.class, () -> test().when().thenDlq().satisfies(record -> {}));
+
+        assertTrue(error.getMessage().contains("Expected at least 1 record(s) on DLQ topic 'DLQ_TOPIC' but found 0"));
+        assertTrue(error.getMessage().contains("<none>"));
+    }
+}

--- a/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/test/GivenStageTest.java
+++ b/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/test/GivenStageTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kstreamplify.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.streams.KeyValue;
+import org.junit.jupiter.api.Test;
+
+class GivenStageTest extends AbstractDslTest {
+    @Test
+    void shouldPipeSingleRecord() {
+        test().given(INPUT)
+                .record("123", "hello")
+                .when()
+                .then(OUTPUT)
+                .hasExactly(1)
+                .containsRecord("123", "HELLO");
+    }
+
+    @Test
+    void shouldPipeMultipleRecords() {
+        test().given(INPUT)
+                .record("1", "a")
+                .record("2", "b")
+                .when()
+                .then(OUTPUT)
+                .containsExactly(Map.entry("1", "A"), Map.entry("2", "B"));
+    }
+
+    @Test
+    void shouldPipeBulkRecords() {
+        test().given(INPUT)
+                .records(List.of(KeyValue.pair("1", "a"), KeyValue.pair("2", "b")))
+                .when()
+                .then(OUTPUT)
+                .containsExactly(Map.entry("1", "A"), Map.entry("2", "B"));
+    }
+
+    @Test
+    void shouldPipeTimestampedRecord() {
+        Instant timestamp = Instant.parse("2026-08-17T10:00:00Z");
+
+        test().given(INPUT)
+                .record("1", "a", timestamp)
+                .when()
+                .then(OUTPUT)
+                .satisfies(record -> assertEquals(timestamp, record.getRecordTime()));
+    }
+
+    @Test
+    void shouldFeedMultipleInputTopicsWithAnd() {
+        test().given(INPUT)
+                .record("1", "a")
+                .and(INPUT_2)
+                .record("2", "b")
+                .when()
+                .then(OUTPUT)
+                .hasExactly(2)
+                .containsKey("1")
+                .containsKey("2");
+    }
+
+    @Test
+    void shouldJoinTwoInputTopics() {
+        test().given(USER_TOPIC)
+                .record("1", "Anna")
+                .and(ORDER_TOPIC)
+                .record("1", "ORDER-1")
+                .when()
+                .then(JOIN_OUTPUT)
+                .hasExactly(1)
+                .containsRecord("1", "ORDER-1-Anna");
+    }
+
+    @Test
+    void shouldAdvanceEventTimeBetweenRecords() {
+        test().given(INPUT)
+                .record("1", "a")
+                .advanceTime(Duration.ofMinutes(5))
+                .record("2", "b")
+                .when()
+                .then(OUTPUT)
+                .satisfies(0, record -> assertEquals(INITIAL_TIME, record.getRecordTime()))
+                .satisfies(1, record -> assertEquals(INITIAL_TIME.plus(Duration.ofMinutes(5)), record.getRecordTime()));
+    }
+
+    @Test
+    void shouldAdvanceWallClockTimeWithoutAffectingEventTime() {
+        test().given(INPUT)
+                .advanceWallClockTime(Duration.ofMinutes(5))
+                .record("1", "a")
+                .when()
+                .then(OUTPUT)
+                .satisfies(record -> assertEquals(INITIAL_TIME, record.getRecordTime()));
+    }
+
+    @Test
+    void shouldNavigateToAssertionsWithoutWhen() {
+        test().given(INPUT).record("1", INVALID_VALUE).thenDlq().hasExactly(1);
+
+        test().given(USER_TOPIC).record("1", "Anna").thenStateStore(USER_STORE).containsKey("1");
+
+        test().given(INPUT).record("2", "b").then(OUTPUT).containsKey("2");
+    }
+}

--- a/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/test/KstreamplifyTestContextTest.java
+++ b/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/test/KstreamplifyTestContextTest.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kstreamplify.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
+
+class KstreamplifyTestContextTest extends AbstractDslTest {
+    @Test
+    void shouldReturnTheSameContextForTheWholeTest() {
+        assertSame(test(), test());
+    }
+
+    @Test
+    void shouldKeepEventTimeAdvancementAcrossTestCalls() {
+        test().advanceTime(Duration.ofMinutes(5));
+
+        test().given(INPUT).record("123", "hello");
+
+        test().then(OUTPUT)
+                .satisfies(record -> assertEquals(INITIAL_TIME.plus(Duration.ofMinutes(5)), record.getRecordTime()));
+    }
+
+    @Test
+    void shouldAdvanceEventTimeFromTheContext() {
+        test().advanceTime(Duration.ofMinutes(10))
+                .given(INPUT)
+                .record("123", "hello")
+                .when()
+                .then(OUTPUT)
+                .satisfies(record -> assertEquals(INITIAL_TIME.plus(Duration.ofMinutes(10)), record.getRecordTime()));
+    }
+
+    @Test
+    void shouldUseInitialWallClockTimeAsDefaultEventTime() {
+        test().given(INPUT)
+                .record("123", "hello")
+                .when()
+                .then(OUTPUT)
+                .satisfies(record -> assertEquals(INITIAL_TIME, record.getRecordTime()));
+    }
+
+    @Test
+    void shouldNotAdvanceEventTimeWhenAdvancingWallClockTime() {
+        test().advanceWallClockTime(Duration.ofMinutes(30))
+                .given(INPUT)
+                .record("123", "hello")
+                .when()
+                .then(OUTPUT)
+                .satisfies(record -> assertEquals(INITIAL_TIME, record.getRecordTime()));
+    }
+
+    @Test
+    void shouldTriggerWallClockPunctuatorWhenAdvancingWallClockTime() {
+        test().when().then(TICK_OUTPUT).isEmpty();
+
+        test().advanceWallClockTime(Duration.ofMinutes(2))
+                .then(TICK_OUTPUT)
+                .hasExactly(1)
+                .containsRecord("tick", "tick");
+
+        test().advanceWallClockTime(Duration.ofMinutes(2)).then(TICK_OUTPUT).hasExactly(2);
+    }
+
+    @Test
+    void shouldMoveEventTimeToTheLastExplicitTimestamp() {
+        Instant timestamp = Instant.parse("2026-08-17T10:00:00Z");
+
+        test().given(INPUT)
+                .record("1", "a", timestamp)
+                .record("2", "b")
+                .when()
+                .then(OUTPUT)
+                .satisfies(1, record -> assertEquals(timestamp, record.getRecordTime()));
+    }
+
+    @Test
+    void shouldAccumulateOutputRecordsAcrossThenCalls() {
+        test().given(INPUT).record("1", "a").when().then(OUTPUT).hasExactly(1);
+
+        test().then(OUTPUT).hasExactly(1).containsKey("1");
+
+        test().given(INPUT)
+                .record("2", "b")
+                .when()
+                .then(OUTPUT)
+                .hasExactly(2)
+                .containsKey("1")
+                .containsKey("2");
+    }
+
+    @Test
+    void shouldAccumulateDlqRecordsAcrossThenDlqCalls() {
+        test().given(INPUT).record("1", INVALID_VALUE).when().thenDlq().hasExactly(1);
+
+        test().thenDlq().hasExactly(1).containsKey("1");
+    }
+
+    @Test
+    void shouldFailWithDiagnosticsWhenStateStoreDoesNotExist() {
+        AssertionFailedError error =
+                assertThrows(AssertionFailedError.class, () -> test().thenStateStore("unknown-store"));
+
+        assertTrue(error.getMessage().contains("No key-value state store named 'unknown-store'"));
+        assertTrue(error.getMessage().contains(USER_STORE));
+    }
+
+    @Test
+    void shouldExposeUnderlyingDriverAsEscapeHatch() {
+        assertNotNull(test().driver());
+        assertNotNull(test().given(INPUT).driver());
+        assertNotNull(test().when().driver());
+        assertNotNull(test().then(OUTPUT).driver());
+        assertNotNull(test().thenDlq().driver());
+        assertNotNull(test().thenStateStore(USER_STORE).driver());
+    }
+}

--- a/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/test/OutputAssertionTest.java
+++ b/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/test/OutputAssertionTest.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kstreamplify.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.kafka.streams.test.TestRecord;
+import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
+
+class OutputAssertionTest extends AbstractDslTest {
+    @Test
+    void shouldAssertRecordCountAndContent() {
+        test().given(INPUT)
+                .record("123", "hello")
+                .when()
+                .then(OUTPUT)
+                .hasExactly(1)
+                .containsKey("123")
+                .doesNotContainKey("456")
+                .containsRecord("123", "HELLO")
+                .containsValue("HELLO"::equals)
+                .containsHeader(CORRELATION_ID, "123")
+                .containsExactly(Map.entry("123", "HELLO"))
+                .allSatisfy(record -> assertEquals("HELLO", record.value()))
+                .satisfies(record -> assertEquals("HELLO", record.value()))
+                .hasExactly(1);
+    }
+
+    @Test
+    void shouldAssertEmptyOutputWhenNoInput() {
+        test().when().then(OUTPUT).isEmpty();
+    }
+
+    @Test
+    void shouldReturnUnmodifiableRecords() {
+        List<TestRecord<String, String>> records =
+                test().given(INPUT).record("1", "a").when().then(OUTPUT).records();
+
+        assertEquals(1, records.size());
+        assertThrows(UnsupportedOperationException.class, () -> records.add(null));
+    }
+
+    @Test
+    void shouldApplyAssertionToEveryRecord() {
+        AtomicInteger counter = new AtomicInteger();
+
+        test().given(INPUT)
+                .record("1", "a")
+                .record("2", "b")
+                .when()
+                .then(OUTPUT)
+                .allSatisfy(record -> counter.incrementAndGet());
+
+        assertEquals(2, counter.get());
+    }
+
+    @Test
+    void shouldFailWhenRecordCountDoesNotMatch() {
+        AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> test().given(INPUT)
+                .record("123", "hello")
+                .when()
+                .then(OUTPUT)
+                .hasExactly(2));
+
+        assertTrue(error.getMessage().contains("Expected 2 record(s) on topic 'OUTPUT' but found 1"));
+        assertTrue(error.getMessage().contains("123=HELLO"));
+    }
+
+    @Test
+    void shouldFailWhenOutputIsNotEmpty() {
+        AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> test().given(INPUT)
+                .record("123", "hello")
+                .when()
+                .then(OUTPUT)
+                .isEmpty());
+
+        assertTrue(error.getMessage().contains("Expected no record on topic 'OUTPUT' but found 1"));
+    }
+
+    @Test
+    void shouldFailWhenKeyIsMissing() {
+        AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> test().given(INPUT)
+                .record("123", "hello")
+                .when()
+                .then(OUTPUT)
+                .containsKey("456"));
+
+        assertTrue(error.getMessage().contains("Expected a record with key '456' on topic 'OUTPUT'"));
+        assertTrue(error.getMessage().contains("123"));
+    }
+
+    @Test
+    void shouldFailWhenKeyIsPresentButNotExpected() {
+        AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> test().given(INPUT)
+                .record("123", "hello")
+                .when()
+                .then(OUTPUT)
+                .doesNotContainKey("123"));
+
+        assertTrue(error.getMessage().contains("Expected no record with key '123' on topic 'OUTPUT'"));
+    }
+
+    @Test
+    void shouldFailWhenRecordIsMissing() {
+        AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> test().given(INPUT)
+                .record("123", "hello")
+                .when()
+                .then(OUTPUT)
+                .containsRecord("123", "WRONG"));
+
+        assertTrue(error.getMessage().contains("Expected a record with key '123' and value 'WRONG'"));
+        assertTrue(error.getMessage().contains("123=HELLO"));
+    }
+
+    @Test
+    void shouldFailWhenNoValueMatchesPredicate() {
+        AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> test().given(INPUT)
+                .record("123", "hello")
+                .when()
+                .then(OUTPUT)
+                .containsValue("WRONG"::equals));
+
+        assertTrue(error.getMessage().contains("Expected a record matching the given value predicate"));
+    }
+
+    @Test
+    void shouldFailWhenHeaderIsMissing() {
+        AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> test().given(INPUT)
+                .record("123", "hello")
+                .when()
+                .then(OUTPUT)
+                .containsHeader(CORRELATION_ID, "456"));
+
+        assertTrue(error.getMessage().contains("Expected a record with header 'correlation-id'='456'"));
+        assertTrue(error.getMessage().contains("123 -> 123"));
+    }
+
+    @Test
+    void shouldFailWithMissingAndUnexpectedKeysWhenExactCollectionSizeDiffers() {
+        AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> test().given(INPUT)
+                .record("1", "a")
+                .when()
+                .then(OUTPUT)
+                .containsExactly(Map.entry("1", "A"), Map.entry("2", "B")));
+
+        assertTrue(error.getMessage().contains("Missing keys:"));
+        assertTrue(error.getMessage().contains("  2"));
+        assertTrue(error.getMessage().contains("Unexpected keys:"));
+    }
+
+    @Test
+    void shouldFailWhenExactCollectionDiffersAtIndex() {
+        AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> test().given(INPUT)
+                .record("1", "a")
+                .record("2", "b")
+                .when()
+                .then(OUTPUT)
+                .containsExactly(Map.entry("1", "A"), Map.entry("2", "WRONG")));
+
+        assertTrue(error.getMessage().contains("Record at index 1 on topic 'OUTPUT' does not match"));
+        assertTrue(error.getMessage().contains("Expected: 2=WRONG"));
+        assertTrue(error.getMessage().contains("Actual:   2=B"));
+    }
+
+    @Test
+    void shouldFailWhenAssertedRecordIndexDoesNotExist() {
+        AssertionFailedError error = assertThrows(
+                AssertionFailedError.class,
+                () -> test().given(INPUT).record("1", "a").when().then(OUTPUT).satisfies(2, record -> {}));
+
+        assertTrue(error.getMessage().contains("Expected at least 3 record(s) on topic 'OUTPUT' but found 1"));
+    }
+
+    @Test
+    void shouldFailWhenApplyingAssertionToEveryRecordOfAnEmptyTopic() {
+        AssertionFailedError error = assertThrows(
+                AssertionFailedError.class, () -> test().when().then(OUTPUT).allSatisfy(record -> {}));
+
+        assertTrue(error.getMessage().contains("Expected at least one record on topic 'OUTPUT' but found none"));
+    }
+}

--- a/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/test/StateStoreAssertionTest.java
+++ b/kstreamplify-core-test/src/test/java/com/michelin/kstreamplify/test/StateStoreAssertionTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.kstreamplify.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
+
+class StateStoreAssertionTest extends AbstractDslTest {
+    @Test
+    void shouldAssertStateStoreContent() {
+        test().given(USER_TOPIC)
+                .record("USER-1", "active")
+                .when()
+                .thenStateStore(USER_STORE)
+                .hasExactly(1)
+                .containsKey("USER-1")
+                .containsValue("active"::equals)
+                .contains("USER-1", "active")
+                .doesNotContainKey("USER-999")
+                .hasExactly(1);
+    }
+
+    @Test
+    void shouldAssertEmptyStateStore() {
+        test().when().thenStateStore(USER_STORE).isEmpty().hasExactly(0);
+    }
+
+    @Test
+    void shouldExposeUnderlyingStore() {
+        assertEquals(
+                "active",
+                test().given(USER_TOPIC)
+                        .record("USER-1", "active")
+                        .when()
+                        .<String, String>thenStateStore(USER_STORE)
+                        .store()
+                        .get("USER-1"));
+    }
+
+    @Test
+    void shouldFailWhenKeyIsMissing() {
+        AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> test().given(USER_TOPIC)
+                .record("USER-1", "active")
+                .when()
+                .thenStateStore(USER_STORE)
+                .containsKey("USER-999"));
+
+        assertTrue(error.getMessage().contains("Expected state store 'user-store' to contain key 'USER-999'"));
+        assertTrue(error.getMessage().contains("USER-1=active"));
+    }
+
+    @Test
+    void shouldFailWhenKeyIsPresentButNotExpected() {
+        AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> test().given(USER_TOPIC)
+                .record("USER-1", "active")
+                .when()
+                .thenStateStore(USER_STORE)
+                .doesNotContainKey("USER-1"));
+
+        assertTrue(error.getMessage()
+                .contains(
+                        "Expected state store 'user-store' not to contain key 'USER-1' but it is mapped to 'active'"));
+    }
+
+    @Test
+    void shouldFailWhenValueDoesNotMatch() {
+        AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> test().given(USER_TOPIC)
+                .record("USER-1", "active")
+                .when()
+                .thenStateStore(USER_STORE)
+                .contains("USER-1", "inactive"));
+
+        assertTrue(error.getMessage()
+                .contains("Expected state store 'user-store' to map key 'USER-1' to 'inactive' but found 'active'"));
+    }
+
+    @Test
+    void shouldFailWhenEntryCountDoesNotMatch() {
+        AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> test().given(USER_TOPIC)
+                .record("USER-1", "active")
+                .when()
+                .thenStateStore(USER_STORE)
+                .hasExactly(2));
+
+        assertTrue(error.getMessage().contains("Expected state store 'user-store' to contain 2 entries but found 1"));
+        assertTrue(error.getMessage().contains("USER-1=active"));
+    }
+
+    @Test
+    void shouldFailWhenStateStoreIsNotEmpty() {
+        AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> test().given(USER_TOPIC)
+                .record("USER-1", "active")
+                .when()
+                .thenStateStore(USER_STORE)
+                .isEmpty());
+
+        assertTrue(error.getMessage().contains("Expected state store 'user-store' to be empty but found 1 entries"));
+    }
+
+    @Test
+    void shouldFailWhenNoValueMatchesPredicate() {
+        AssertionFailedError error = assertThrows(AssertionFailedError.class, () -> test().given(USER_TOPIC)
+                .record("USER-1", "active")
+                .when()
+                .thenStateStore(USER_STORE)
+                .containsValue("inactive"::equals));
+
+        assertTrue(error.getMessage()
+                .contains("Expected state store 'user-store' to contain a value matching the given predicate"));
+    }
+}


### PR DESCRIPTION
Closes #558
Adds a fluent, type-safe Given → When → Then testing DSL to kstreamplify-core-test, available through a new test() method on KafkaStreamsStarterTest. Tests no longer need to declare and wire TestInputTopic/TestOutputTopic fields or read and assert records manually: the DSL reuses TopicWithSerde as the single source of topic and SerDe information and provides typed output assertions (hasExactly, containsKey, containsRecord, containsValue, containsHeader, containsExactly, satisfies, allSatisfy, ...), first-class DLQ assertions that hide the internal KafkaError behind a DlqRecord, state store assertions, multiple input topics via and(...), timestamped records, event-time and wall-clock control that preserves the Kafka Streams distinction between the two, chaining across several output topics, the DLQ and state stores in a single scenario, and failure messages reporting the topic, the expectation and the records actually produced. The change is purely additive — kstreamplify-core is untouched, existing tests and createInputTestTopic(...)/createOutputTestTopic(...) keep working, and driver() is exposed on every stage as an escape hatch to the underlying TopologyTestDriver. It comes with 70 unit tests covering every assertion and failure message over a topology exercising multiple inputs, DLQ routing, headers, a stream-table join, a state store and a wall-clock punctuator, plus a README section documenting the new recommended test style.