### PR TITLE
Fix punctuator exception handled by `ProcessingExceptionHandler`

### DIFF
--- a/kstreamplify-core/src/main/java/com/michelin/kstreamplify/error/DlqExceptionHandler.java
+++ b/kstreamplify-core/src/main/java/com/michelin/kstreamplify/error/DlqExceptionHandler.java
@@ -58,7 +58,9 @@ public abstract class DlqExceptionHandler {
                                         + " bytes). The key will be used instead"
                                 : null)
                 .setByteValue(
-                        tooLarge ? key != null ? ByteBuffer.wrap(key) : null : value != null ? ByteBuffer.wrap(value) : null);
+                        tooLarge
+                                ? key != null ? ByteBuffer.wrap(key) : null
+                                : value != null ? ByteBuffer.wrap(value) : null);
     }
 
     /**

--- a/kstreamplify-core/src/main/java/com/michelin/kstreamplify/error/DlqExceptionHandler.java
+++ b/kstreamplify-core/src/main/java/com/michelin/kstreamplify/error/DlqExceptionHandler.java
@@ -57,7 +57,8 @@ public abstract class DlqExceptionHandler {
                                 ? "The record is too large to be set as value (" + value.length
                                         + " bytes). The key will be used instead"
                                 : null)
-                .setByteValue(tooLarge ? ByteBuffer.wrap(key) : ByteBuffer.wrap(value));
+                .setByteValue(
+                        tooLarge ? key != null ? ByteBuffer.wrap(key) : null : value != null ? ByteBuffer.wrap(value) : null);
     }
 
     /**

--- a/kstreamplify-core/src/main/java/com/michelin/kstreamplify/error/DlqProcessingExceptionHandler.java
+++ b/kstreamplify-core/src/main/java/com/michelin/kstreamplify/error/DlqProcessingExceptionHandler.java
@@ -72,7 +72,7 @@ public class DlqProcessingExceptionHandler extends DlqExceptionHandler implement
             Serde<KafkaError> serde = SerdesUtils.getValueSerdes();
             byte[] value = serde.serializer().serialize(KafkaStreamsExecutionContext.getDlqTopicName(), error);
 
-            byte[] key = processingRecord.key() != null
+            byte[] key = processingRecord != null && processingRecord.key() != null
                     ? processingRecord.key().toString().getBytes()
                     : null;
 
@@ -103,26 +103,26 @@ public class DlqProcessingExceptionHandler extends DlqExceptionHandler implement
                         "An exception occurred during the stream processing of a record. Please find more details about the exception in the cause and stack fields.")
                 .setOffset(context.offset())
                 .setPartition(context.partition())
-                .setTopic(context.topic())
+                .setTopic(context.topic() != null ? context.topic() : "Outside topic context")
                 .setApplicationId(KafkaStreamsExecutionContext.getProperties().getProperty(APPLICATION_ID_CONFIG))
                 .setProcessorNodeId(context.processorNodeId())
                 .setTaskId(context.taskId().toString())
-                .setSourceRawKey(ByteBuffer.wrap(context.sourceRawKey()))
-                .setSourceRawValue(ByteBuffer.wrap(context.sourceRawValue()))
+                .setSourceRawKey(context.sourceRawKey() != null ? ByteBuffer.wrap(context.sourceRawKey()) : null)
+                .setSourceRawValue(context.sourceRawValue() != null ? ByteBuffer.wrap(context.sourceRawValue()) : null)
                 .setValue(
-                        processingRecord.value() == null
+                        processingRecord == null || processingRecord.value() == null
                                 ? null
                                 : processingRecord.value().toString());
 
         return enrichWithException(
-                        builder,
-                        exception,
-                        processingRecord.key() != null
-                                ? processingRecord.key().toString().getBytes()
-                                : null,
-                        processingRecord.value() != null
-                                ? processingRecord.value().toString().getBytes()
-                                : null)
+                builder,
+                exception,
+                processingRecord != null && processingRecord.key() != null
+                        ? processingRecord.key().toString().getBytes()
+                        : null,
+                processingRecord != null && processingRecord.value() != null
+                        ? processingRecord.value().toString().getBytes()
+                        : null)
                 .build();
     }
 

--- a/kstreamplify-core/src/main/java/com/michelin/kstreamplify/error/DlqProcessingExceptionHandler.java
+++ b/kstreamplify-core/src/main/java/com/michelin/kstreamplify/error/DlqProcessingExceptionHandler.java
@@ -115,14 +115,14 @@ public class DlqProcessingExceptionHandler extends DlqExceptionHandler implement
                                 : processingRecord.value().toString());
 
         return enrichWithException(
-                builder,
-                exception,
-                processingRecord != null && processingRecord.key() != null
-                        ? processingRecord.key().toString().getBytes()
-                        : null,
-                processingRecord != null && processingRecord.value() != null
-                        ? processingRecord.value().toString().getBytes()
-                        : null)
+                        builder,
+                        exception,
+                        processingRecord != null && processingRecord.key() != null
+                                ? processingRecord.key().toString().getBytes()
+                                : null,
+                        processingRecord != null && processingRecord.value() != null
+                                ? processingRecord.value().toString().getBytes()
+                                : null)
                 .build();
     }
 

--- a/kstreamplify-core/src/test/java/com/michelin/kstreamplify/error/DlqExceptionHandlerTest.java
+++ b/kstreamplify-core/src/test/java/com/michelin/kstreamplify/error/DlqExceptionHandlerTest.java
@@ -73,4 +73,23 @@ class DlqExceptionHandlerTest {
                 "The record is too large to be set as value (5 bytes). " + "The key will be used instead",
                 error.getValue());
     }
+
+    @Test
+    void shouldEnrichWithNullKeyAndNullValue() {
+        KafkaError.Builder kafkaError = KafkaError.newBuilder()
+                .setTopic("topic")
+                .setStack("stack")
+                .setPartition(0)
+                .setOffset(0)
+                .setCause("cause")
+                .setValue("value");
+
+        DlqProductionExceptionHandler handler = new DlqProductionExceptionHandler();
+        KafkaError.Builder enrichedBuilder =
+                handler.enrichWithException(kafkaError, new RuntimeException("Exception..."), null, null);
+
+        KafkaError error = enrichedBuilder.build();
+        assertEquals("Unknown cause", error.getCause());
+        assertNull(error.getByteValue());
+    }
 }


### PR DESCRIPTION
This PR fixes exceptions that can occur when a punctuator throws an exception that is handled by the ProcessingExceptionHandler:

